### PR TITLE
貸出編集機能追加

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -16,7 +16,9 @@ import jp.co.metateam.library.model.RentalManageDto;
 
 import jp.co.metateam.library.model.Account;
 import jp.co.metateam.library.model.Stock;
+
 import jp.co.metateam.library.values.RentalStatus;
+import jp.co.metateam.library.values.StockStatus;
 
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -26,6 +28,9 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import jakarta.validation.Valid;
 
 
+//ここ追加インポート
+import org.springframework.web.bind.annotation.RequestParam;//(5/14)
+
 /**
  * 貸出管理関連クラスß
  */
@@ -33,16 +38,27 @@ import jakarta.validation.Valid;
 @Controller
 public class RentalManageController {
 
+    //final修飾子で変数が初期化された後の変更を拒否
+    //フィールド宣言（AccountServiceなど）をして変数を定義（accountService）
     private final AccountService accountService;
     private final RentalManageService rentalManageService;
     private final StockService stockService;
 
+    //インスタンス生成の際に呼び出されるコンストラクタの定義
+    /*AutowiredによってSpringFrameworkがDI（Dependency Injection）を行う。
+     *DIによって、クラス間の依存関係を明示的にせずに、それらの依存関係を容易に変更したりすることができる。
+     *要は下記3つのインスタンスを、具体的な実装関係なく参照することができる。
+     *　→参照するクラスの実装を変えても、このクラスのコードは変えなくてもいい。柔軟性の高いコーディング。
+    */
     @Autowired
     public RentalManageController(
+        //AccountServiceというクラスのaccountServiceというインスタンスを参照。
         AccountService accountService, 
         RentalManageService rentalManageService, 
         StockService stockService
     ) {
+        //コンストラクターで受け取ったaccountServiceをRentalManageControllerクラスのインスタンス変数に格納する。
+        //this.accountService→このクラスでの変数accountServiceは、右辺のaccountService(上で参照したのと同じ)と同じものです、と定義。
         this.accountService = accountService;
         this.rentalManageService = rentalManageService;
         this.stockService = stockService;
@@ -50,23 +66,33 @@ public class RentalManageController {
 
     /**
      * 貸出一覧画面初期表示
-     * @param model
-     * @return
+     * @param model　//Modelオブジェクトが引数として渡されています。SpringMVCが提供するモデルオブジェクト。
+     * @return //メソッドが返す値や戻り値に関する情報を提供するために使用される。つまりどういうこと？
      */
+    //「/rental/index」というURI(貸出一覧画面)へのGETリクエストがこのメソッドに送信されると、そのリクエストを処理するためにこのメソッドが呼び出される。
     @GetMapping("/rental/index")
+    //メソッド名がindex、引数名がmodel。
     public String index(Model model) {
         // 貸出管理テーブルから全件取得
+        //取得した貸出管理情報は、変数RentalManageList に代入されており、この変数には全ての貸出管理情報が含まれる。
+        //this.rentalManageServiceサービスについては上述
         List<RentalManage> RentalManageList = this.rentalManageService.findAll();
         // 貸出一覧画面に渡すデータをmodelに追加
+        //addAttributeは属性追加のメソッド。()内に名前と、属性として追加する変数（一行上で定義）を記述する。
         model.addAttribute("rentalManageList", RentalManageList);
         // 貸出一覧画面に遷移
+        //rental/indexを返している。引数が文字列だが、これはパス名を指している。
+        //この行を使うことで、このメソッドが実行された後に、指定されたビュー(rental/index)に遷移することができる。
         return "rental/index";
     }
     
 
+    //Springのアノテーションを使用。GETリクエストが "/rental/add" というURLに対応
+    //アノテーション…
     @GetMapping("/rental/add")
+    //引数のModelオブジェクトは、ビューにデータを渡すためのもの
     public String add(Model model) {
-
+        //Stockクラスのインスタンスリストを取得。変数名stockList。
         List <Stock> stockList = this.stockService.findAll();
         List <Account> accounts = this.accountService.findAll();
 
@@ -100,6 +126,128 @@ public class RentalManageController {
             return "redirect:/rental/add";
         }
     }
-    
 
-}
+    /*　貸出編集画面 */
+    @GetMapping("/rental/{id}/edit")
+    public String edit(@PathVariable("id") String id, Model model, @RequestParam(name = "errorMessage", required = false) String errorMessage) {
+        List<RentalManage> rentalManageList = this.rentalManageService.findAll();
+ 
+        List<Account> accounts = this.accountService.findAll();
+        List<Stock> stockList = this.stockService.findAll();
+ 
+        model.addAttribute("accounts", accounts);
+        model.addAttribute("stockList", stockList);
+        model.addAttribute("rentalStatus", RentalStatus.values());
+ 
+        model.addAttribute("rentalManageList", rentalManageList);
+        model.addAttribute("rentalStockStatus", StockStatus.values());
+ 
+        if (errorMessage != null) {
+            model.addAttribute("errorMessage", errorMessage);
+        }
+
+        if (!model.containsAttribute("rentalManageDto")) {
+            RentalManageDto rentalManageDto = new RentalManageDto();
+            Long idLong = Long.parseLong(id);
+            RentalManage rentalManage = this.rentalManageService.findById(idLong);
+
+ 
+            rentalManageDto.setEmployeeId(rentalManage.getAccount().getEmployeeId());
+ 
+            rentalManageDto.setId(rentalManage.getId());
+            rentalManageDto.setExpectedRentalOn(rentalManage.getExpectedRentalOn());
+            rentalManageDto.setExpectedReturnOn(rentalManage.getExpectedReturnOn());
+            rentalManageDto.setStatus(rentalManage.getStatus());
+            rentalManageDto.setStockId(rentalManage.getStock().getId());
+ 
+            model.addAttribute("rentalManageDto", rentalManageDto);
+        }
+ 
+        return "rental/edit";
+    }
+
+
+
+    
+    @PostMapping("/rental/{id}/edit")
+    public String update(@PathVariable("id") Long id, @Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, Model model) {
+        try {
+            // バリデーションエラーチェック
+            if (result.hasErrors()) {
+                model.addAttribute("errorMessage", "入力内容にエラーがあります");
+                // バリデーションエラーがある場合は編集画面に戻る
+                List<Stock> stockList = this.stockService.findStockAvailableAll();
+                List<Account> accounts = this.accountService.findAll();
+                model.addAttribute("accounts", accounts);
+                model.addAttribute("stockList", stockList);
+                model.addAttribute("rentalStatus", RentalStatus.values());
+                return "rental/edit";
+            }
+    
+            // 貸出情報を取得
+            RentalManage rentalManage = this.rentalManageService.findById(id);
+            if (rentalManage == null) {
+                model.addAttribute("errorMessage", "指定された貸出情報が見つかりません");
+                // 貸出情報が見つからない場合は編集画面に戻る
+                List<Stock> stockList = this.stockService.findStockAvailableAll();
+                List<Account> accounts = this.accountService.findAll();
+                model.addAttribute("accounts", accounts);
+                model.addAttribute("stockList", stockList);
+                model.addAttribute("rentalStatus", RentalStatus.values());
+                return "rental/edit";
+            }
+    
+            // 貸出情報のステータスをチェック
+            String statusErrorMessage = rentalManageDto.isValidStatus(rentalManage.getStatus());
+            if (statusErrorMessage != null) {
+                model.addAttribute("errorMessage", statusErrorMessage);
+                // ステータスが無効な場合は編集画面に戻る
+                List<Stock> stockList = this.stockService.findStockAvailableAll();
+                List<Account> accounts = this.accountService.findAll();
+                model.addAttribute("accounts", accounts);
+                model.addAttribute("stockList", stockList);
+                model.addAttribute("rentalStatus", RentalStatus.values());
+                return "rental/edit";
+            }
+    
+            // 貸出予定日のバリデーションチェック
+            if (rentalManage.getStatus() == RentalStatus.RENT_WAIT.getValue() &&
+                rentalManageDto.getStatus() == RentalStatus.RENTAlING.getValue()){
+            if (!rentalManageDto.isValidRentalDate()) {
+       
+                model.addAttribute("errorMessage", "貸出予定日は現在の日付に設定してください");
+                List<Stock> stockList = this.stockService.findStockAvailableAll();
+                List<Account> accounts = this.accountService.findAll();
+                model.addAttribute("accounts", accounts);
+                model.addAttribute("stockList", stockList);
+                model.addAttribute("rentalStatus", RentalStatus.values());
+                return "rental/edit";
+                }
+            //返却予定日のバリデーションチェック
+            }else if (rentalManage.getStatus() == RentalStatus.RENTAlING.getValue() &&
+                rentalManageDto.getStatus() == RentalStatus.RETURNED.getValue()) {
+            if(!rentalManageDto.isValidReturnDate()) {
+        
+                model.addAttribute("errorMessage", "返却予定日は現在の日付に設定してください");
+                List<Stock> stockList = this.stockService.findStockAvailableAll();
+                List<Account> accounts = this.accountService.findAll();
+                model.addAttribute("accounts", accounts);
+                model.addAttribute("stockList", stockList);
+                model.addAttribute("rentalStatus", RentalStatus.values());
+                return "rental/edit";
+                }
+            }
+            // 更新処理
+            this.rentalManageService.update(id, rentalManageDto);
+            return "redirect:/rental/index";
+            } catch (Exception e) {
+            // エラーが発生した場合の処理
+            log.error("更新処理中にエラーが発生しました: " + e.getMessage());
+            model.addAttribute("errorMessage", "更新処理中にエラーが発生しました");
+            return "rental/edit";
+        }
+    }
+    
+    
+} 
+  

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -1,14 +1,17 @@
 package jp.co.metateam.library.model;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.util.Date;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jp.co.metateam.library.values.RentalStatus;
 import lombok.Getter;
 import lombok.Setter;
+
 
 /**
  * 貸出管理DTO
@@ -45,4 +48,53 @@ public class RentalManageDto {
     private Stock stock;
 
     private Account account;
+
+    ////加えました（5/13）
+    private Integer newStatus;  
+
+    // getStatusメソッドを追加
+    public Integer getStatus() {
+        return this.status;
+    }
+
+    // getNewStatusメソッドを追加
+    public Integer getNewStatus() {
+        return this.newStatus;
+    }    
+    ////ここまでです
+
+    ////加えました（5/14） 
+        // 貸出状態が有効かどうかをチェックするメソッド
+            public String isValidStatus(Integer previousStatus) {
+                if(previousStatus == RentalStatus.RENT_WAIT.getValue() && this.status == RentalStatus.RETURNED.getValue()){
+                    return "貸出ステータスは「貸出待ち」から「返却済み」に変更できません";
+                }else if(previousStatus == RentalStatus.RENTAlING.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()){
+                    return "貸出ステータスは「貸出中」から「貸出待ち」に変更できません";
+                }else if(previousStatus == RentalStatus.RENTAlING.getValue() && this.status == RentalStatus.CANCELED.getValue()){
+                    return "貸出ステータスは「貸出中」から「キャンセル」に変更できません";
+                }else if(previousStatus == RentalStatus.RETURNED.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()){
+                    return "貸出ステータスは「返却済み」から「貸出待ち」に変更できません";
+                }else if(previousStatus == RentalStatus.RETURNED.getValue() && this.status == RentalStatus.RENTAlING.getValue()){
+                     return "貸出ステータスは「返却済み」から「貸出中」に変更できません";
+                }else if(previousStatus == RentalStatus.RETURNED.getValue() && this.status == RentalStatus.CANCELED.getValue()){
+                    return "貸出ステータスは「返却済み」から「キャンセル」に変更できません";
+                }else if(previousStatus == RentalStatus.CANCELED.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()){
+                    return "貸出ステータスは「キャンセル」から「貸出待ち」に変更できません";
+                }else if(previousStatus == RentalStatus.CANCELED.getValue() && this.status == RentalStatus.RENTAlING.getValue()){
+                    return "貸出ステータスは「キャンセル」から「貸出中」に変更できません";
+                }else if(previousStatus == RentalStatus.CANCELED.getValue() && this.status == RentalStatus.RETURNED.getValue()){
+                    return "貸出ステータスは「キャンセル」から「返却済み」に変更できません";
+                }
+                return null;
+            }
+
+            public boolean isValidRentalDate() {
+                LocalDate today = LocalDate.now();
+                return expectedRentalOn.equals(today); // または必要に応じて条件を調整
+            }
+            public boolean isValidReturnDate() {
+                LocalDate today = LocalDate.now();
+                return expectedReturnOn.equals(today); // または必要に応じて条件を調整
+            }
+    
 }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -4,13 +4,16 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.RentalManage;
 
 @Repository
 public interface RentalManageRepository extends JpaRepository<RentalManage, Long> {
+    @NonNull
     List<RentalManage> findAll();
 
-	Optional<RentalManage> findById(Long id);
+    @NonNull
+    Optional<RentalManage> findById(@NonNull Long id);
 }

--- a/src/main/java/jp/co/metateam/library/service/RentalManageService.java
+++ b/src/main/java/jp/co/metateam/library/service/RentalManageService.java
@@ -6,15 +6,18 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import jp.co.metateam.library.model.Account;
+
+
 import jp.co.metateam.library.model.RentalManage;
 import jp.co.metateam.library.model.RentalManageDto;
 import jp.co.metateam.library.model.Stock;
+
 import jp.co.metateam.library.repository.AccountRepository;
 import jp.co.metateam.library.repository.RentalManageRepository;
 import jp.co.metateam.library.repository.StockRepository;
 import jp.co.metateam.library.values.RentalStatus;
+
 
 @Service
 public class RentalManageService {
@@ -74,6 +77,50 @@ public class RentalManageService {
             throw e;
         }
     }
+
+
+    //アップデートを追加します
+    
+    @Transactional
+    public void update(Long id, RentalManageDto rentalManageDto) throws Exception {
+       
+       
+        try {
+ 
+            Account account = this.accountRepository.findByEmployeeId(rentalManageDto.getEmployeeId()).orElse(null);
+            if (account == null) {
+                throw new Exception("Rental record not found.");
+            }
+            Stock stock = this.stockRepository.findById(rentalManageDto.getStockId()).orElse(null);
+            if (stock == null) {
+                throw new Exception("Rental record not found.");
+            }
+           
+            RentalManage rentalManage = this.rentalManageRepository.findById(id).orElse(null);
+            if (rentalManage == null) {
+                throw new Exception("RentalManage record not found.");
+            }
+ 
+                setRentalStatusDate(rentalManage, rentalManageDto.getStatus());
+   
+                rentalManage.setId(rentalManageDto.getId());
+                rentalManage.setAccount(account);
+                rentalManage.setExpectedRentalOn(rentalManageDto.getExpectedRentalOn());
+                rentalManage.setExpectedReturnOn(rentalManageDto.getExpectedReturnOn());
+                rentalManage.setStatus(rentalManageDto.getStatus());
+                rentalManage.setStock(stock);
+   
+   
+               
+   
+            // データベースへの保存
+            this.rentalManageRepository.save(rentalManage);
+        } catch (Exception e) {
+            throw e;
+        }
+
+    }
+
 
     private RentalManage setRentalStatusDate(RentalManage rentalManage, Integer status) {
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());

--- a/src/main/java/jp/co/metateam/library/values/RentalStatus.java
+++ b/src/main/java/jp/co/metateam/library/values/RentalStatus.java
@@ -13,4 +13,6 @@ public enum RentalStatus implements Values {
 
     private final Integer value;
     private final String text;  
+
+    
 }

--- a/src/main/resources/static/css/rental/edit.css
+++ b/src/main/resources/static/css/rental/edit.css
@@ -27,3 +27,12 @@ label.input_title {
     border-radius: 0.5rem;
     border: none;
 }
+
+/* rental/edit.css */
+/* 5/14に追加 */
+.alert.alert-danger p {
+    color: rgb(255, 0, 0); /* エラーメッセージのフォントカラーを赤色に設定 */
+    margin-top: 5px; /* エラーメッセージの上側の余白を追加 */
+    font-size: 16px; /* エラーメッセージのフォントサイズを調整 */
+}
+

--- a/src/main/resources/templates/rental/edit.html
+++ b/src/main/resources/templates/rental/edit.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="~{common :: meta_header('貸出編集',~{::link},~{::script})}">
+    <title th:text="${title}+' | MTLibrary'"></title>
+    <link rel="stylesheet" th:href="@{/css/rental/add.css}" />
+    <script type="text/javascript" th:src="@{/js/rental/add.js}"></script>
+</head>
+
+<body>
+    <div class="contents">
+        <div th:replace="~{common :: main_sidebar}"></div>
+        <div class="main_contents">
+            <div th:replace="~{common :: header}"></div>
+            <div class="inner_contens">
+                <div class="page_title">貸出編集</div>
+                <div class="mb30 flexarea">
+                    <span class="text-red">＊は必須項目です</span>
+                    <span>
+                        <a th:href="@{/rental/index}" class="link">← 一覧へ戻る</a>
+                    </span>
+                </div>
+                <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/add}" method="post">
+                    <div class="mb30">
+                        <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
+                        <select id="employeeId" class="form_input" name="employeeId" required>
+                            <option value="">社員番号を選択</option>
+                            <option th:each="account : ${accounts}" th:value="${account.employeeId}"
+                                th:text="${account.employeeId + ' ' + account.name}"
+                                th:selected="${account.employeeId == rentalManageDto.employeeId}"></option>
+                        </select>
+                        <div class="error_msg" th:if="${#fields.hasErrors('employeeId')}" th:errors="*{employeeId}">
+                        </div>
+                    </div>
+                    <div class="mb30">
+                        <label class="input_title" for="expectedRentalOn">貸出予定日<span
+                                class="text-red asterisk">＊</span></label>
+                        <input type="date" id="expectedRentalOn" class="form_input" name="expectedRentalOn"
+                            th:value="${#dates.format(rentalManageDto.expectedRentalOn, ('yyyy-MM-dd'))}"
+                            placeholder="貸出予定日を入力" required>
+                        <div class="error_msg" th:if="${#fields.hasErrors('expectedRentalOn')}"
+                            th:errors="*{expectedRentalOn}"></div>
+                    </div>
+                    <div class="mb30">
+                        <label class="input_title" for="expectedReturnOn">返却予定日<span
+                                class="text-red asterisk">＊</span></label>
+                        <input type="date" id="expectedReturnOn" class="form_input" name="expectedReturnOn"
+                            th:value="${#dates.format(rentalManageDto.expectedReturnOn, ('yyyy-MM-dd'))}"
+                            placeholder="返却予定日を入力" required>
+                        <div class="error_msg" th:if="${#fields.hasErrors('expectedReturnOn')}"
+                            th:errors="*{expectedReturnOn}"></div>
+                    </div>
+                    <div class="mb30">
+                        <label class="input_title" for="stockMngNumber">在庫管理番号<span
+                                class="text-red asterisk">＊</span></label>
+                        <select id="stockMngNumber" class="form_input" name="stockId" required>
+                            <option value="">在庫管理番号を選択</option>
+                            <option th:each="stock : ${stockList}" th:value="${stock.id}"
+                                th:text="${stock.id + ' ' + stock.bookMst.title}"
+                                th:selected="${stock.id == rentalManageDto.stockId}"></option>
+                        </select>
+                        <div class="error_msg" th:if="${#fields.hasErrors('stockId')}" th:errors="*{stockId}"></div>
+                    </div>
+                    <div class="mb30">
+                        <label class="input_title" for="rentalStatus">貸出ステータス<span
+                                class="text-red asterisk">＊</span></label>
+                        <select id="rentalStatus" class="form_input" name="status" required>
+                            <option value="">ステータスを選択</option>
+                            <option th:each="status : ${rentalStatus}" th:value="${status.value}"
+                                th:text="${status.text}" th:selected="${status.value == rentalManageDto.status}">
+                            </option>
+                        </select>
+                        <div class="error_msg" th:if="${#fields.hasErrors('status')}" th:errors="*{status}"></div>
+                    </div>
+                    <div class="btn_block">
+                        <button type="submit" id="submit_btn">保存</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div th:replace="~{common :: footer}"></div>
+</body>

--- a/src/main/resources/templates/rental/edit.html
+++ b/src/main/resources/templates/rental/edit.html
@@ -3,8 +3,8 @@
 
 <head th:replace="~{common :: meta_header('貸出編集',~{::link},~{::script})}">
     <title th:text="${title}+' | MTLibrary'"></title>
-    <link rel="stylesheet" th:href="@{/css/rental/add.css}" />
-    <script type="text/javascript" th:src="@{/js/rental/add.js}"></script>
+    <link rel="stylesheet" th:href="@{/css/rental/edit.css}" />
+    <script type="text/javascript" th:src="@{/js/rental/edit.js}"></script>
 </head>
 
 <body>
@@ -20,7 +20,8 @@
                         <a th:href="@{/rental/index}" class="link">← 一覧へ戻る</a>
                     </span>
                 </div>
-                <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/add}" method="post">
+                <form id="rental_edit_form" th:object="${rentalManageDto}" th:action="@{/rental/{id}/edit(id=*{id})}" method="post">
+
                     <div class="mb30">
                         <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
                         <select id="employeeId" class="form_input" name="employeeId" required>
@@ -72,10 +73,17 @@
                         </select>
                         <div class="error_msg" th:if="${#fields.hasErrors('status')}" th:errors="*{status}"></div>
                     </div>
+                    
+                    <!-- エラーメッセージを追加 -->
+                    <div th:if="${errorMessage}" class="alert alert-danger" role="alert">
+                        <p th:text="${errorMessage}"></p>
+                    </div>
+
                     <div class="btn_block">
-                        <button type="submit" id="submit_btn">保存</button>
+                        <input id="submit_btn" type="submit" value="変更">
                     </div>
                 </form>
+
             </div>
         </div>
     </div>


### PR DESCRIPTION
**・概要**

貸出編集画面（rental.edit）を追加しました。
貸出編集機能（RentalMangeController等）を追加しました。
updateメソッドを追加し、貸出情報を編集し更新できるように実装しました。また、その際のバリデーションチェックについても補填しました。具体的には、貸出ステータスの変更に伴うエラーが表示されます。

**・テスト証跡**

正規の値の場合：貸出一覧画面の表示　→　リスト内の編集アイコンを押下　→　貸出編集画面の表示　→　貸出情報の編集　→　更新ボタン押下　→　貸出一覧画面へ遷移　→　更新した情報が表示されている。

誤った値の場合：貸出一覧画面の表示　→　リスト内の編集アイコンを押下　→　貸出編集画面の表示　→　貸出情報の編集　→　更新ボタン押下　→　エラーメッセージ表示（貸出一覧画面に遷移せず）

**・備考**

コードの理解を深めるため、学習内容を書き込んでいる部分がございます。ご了承いただけますと幸いです。