### PR TITLE
貸出編集画面

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -16,11 +16,11 @@ import jp.co.metateam.library.model.RentalManageDto;
 
 import jp.co.metateam.library.model.Account;
 import jp.co.metateam.library.model.Stock;
-
 import jp.co.metateam.library.values.RentalStatus;
 import jp.co.metateam.library.values.StockStatus;
 
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,8 +28,12 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import jakarta.validation.Valid;
 
 
-//ここ追加インポート
+//追加インポート
 import org.springframework.web.bind.annotation.RequestParam;//(5/14)
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+
 
 /**
  * 貸出管理関連クラスß
@@ -85,42 +89,116 @@ public class RentalManageController {
         //この行を使うことで、このメソッドが実行された後に、指定されたビュー(rental/index)に遷移することができる。
         return "rental/index";
     }
-    
 
-    //Springのアノテーションを使用。GETリクエストが "/rental/add" というURLに対応
+    //Springのアノテーションを使用。GETリクエストが "/rental/add" というURLに対応。
     //アノテーション…
     @GetMapping("/rental/add")
-    //引数のModelオブジェクトは、ビューにデータを渡すためのもの
+    //引数のModelオブジェクトは、ビューにデータを渡すためのもの。
     public String add(Model model) {
-        //Stockクラスのインスタンスリストを取得。変数名stockList。
+        //Stock・Accountクラスのインスタンスリストを取得。変数名stockList・accounts。
+        //本クラスで定義したstockService・accountServiceの全ての情報を取得
         List <Stock> stockList = this.stockService.findAll();
         List <Account> accounts = this.accountService.findAll();
-
+        //モデルに情報のリストを追加する。
+        //addAttribute()はモデルに属性を追加するメソッド。属性は“名前”と値のペアで構成。
+        //上記より、ビュー（HTMLテンプレート）において${accounts}の様な仕方でこれらの属性にアクセスが可能。
         model.addAttribute("accounts", accounts);
         model.addAttribute("stockList", stockList);
+        /*RentalStatus.values()について。
+        //RentalStatusクラスの列挙型を全権取得している。
+        //Javaの列挙型(enum)は、複数の定数(値)を定義するための特殊な型。
+        //列挙型の使用で、関連する定数(値)をグループ化し、プログラム内で使いやすくなる。
+        今回は、
+        public enum RentalStatus implements Values {
+            RENT_WAIT(0, "貸出待ち")
+            , RENTAlING(1, "貸出中")
+            , RETURNED(2, "返却済み")
+            , CANCELED(3, "キャンセル");    
+        }
+        */
         model.addAttribute("rentalStatus", RentalStatus.values());
-
+        /*モデルに"rentalManageDto"という名前の属性が含まれていない場合は、新しいRentalManageDtoオブジェクトをモデルに追加する。
+        　上記は、フォームを初期化するために使用される（？）。
+         */
         if (!model.containsAttribute("rentalManageDto")) {
             model.addAttribute("rentalManageDto", new RentalManageDto());
         }
- 
+
+        // モデルに貸出管理DTOを追加
+        if (!model.containsAttribute("rentalManageDto")) {
+            model.addAttribute("rentalManageDto", new RentalManageDto());
+        }
+
+
+
         return "rental/add";
     }
 
+    //利用可否チェック
+    private String checkInventoryStatus(String id) {
+        // 在庫ステータスを確認するロジックを記述
+        Stock stock = this.stockService.findById(id);
+            if (stock.getStatus() == 0) {
+                return null; // 利用可の場合はエラーメッセージなし
+            } else {
+                return "この本は利用できません"; // 利用不可の場合はエラーメッセージを返す
+            }
+    }
+
+    //貸出可否チェック（登録時）
+    public String rentalCheck(RentalManageDto rentalManageDto, String id) {
+        List<RentalManage> rentalAvailable = this.rentalManageService.findByStockIdAndStatusIn(id);
+        if (rentalAvailable != null) {
+            // ループ処理
+            for (RentalManage rentalManage : rentalAvailable) {
+                if (rentalManage.getExpectedReturnOn().after(rentalManageDto.getExpectedRentalOn())
+                        && rentalManage.getExpectedRentalOn().before(rentalManageDto.getExpectedReturnOn())) {
+                    return "貸出期間が重複しています";
+                }
+            }
+            return null;
+        } else {
+            return null;
+        }
+    }
+
+    //POSTリクエストが "/rental/add" というURLに対応。
     @PostMapping("/rental/add")
+    /*HTTP POSTリクエストが "/rental/add" に送信されたときに呼び出される。
+    @Validアノテーションは、rentalManageDtoオブジェクトのバリデーションを有効にする
+    BindingResultオブジェクトはバインディング結果を保持する。
+    @ModelAttributeアノテーションは、リクエストパラメーターをJavaオブジェクトにバインドします。*/
     public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, RedirectAttributes ra) {
         try {
+            //ここから追加です（5/17）
+            String errorMessage = checkInventoryStatus(rentalManageDto.getStockId());
+                if (errorMessage != null) {
+                    result.addError(new FieldError("rentalManageDto", "stockId", errorMessage));
+            }
+            //ここから追加です（5/16）
+            String DateError = this.rentalCheck(rentalManageDto,rentalManageDto.getStockId());
+                if (DateError != null) {
+                    // rentalManageDtoからexpectedRentalOnとexpectedReturnOnの値を取得して、FieldErrorオブジェクトに追加する
+                    result.addError(new FieldError("rentalManageDto", "expectedRentalOn", DateError));
+                    result.addError(new FieldError("rentalManageDto", "expectedReturnOn", DateError));
+                }
+            //ここまで
+
+            //バリデーションエラーが発生した場合、例外がスロー。
             if (result.hasErrors()) {
                 throw new Exception("Validation error.");
             }
-            // 登録処理
+
+            // 登録処理。RentalMangeServiceを使用し、rentalManageDtoオブジェクトを保存する（返す？）
             this.rentalManageService.save(rentalManageDto);
  
             return "redirect:/rental/index";
         } catch (Exception e) {
             log.error(e.getMessage());
- 
+            /*リダイレクト先のビューにデータを渡すためのフラッシュ属性"rentalManageDto"を追加。
+            フラッシュ属性...リダイレクト先のリクエスト「のみ」で利用可能であり、セッションに保存された後に自動的に削除される */
             ra.addFlashAttribute("rentalManageDto", rentalManageDto);
+            //(バリデーションチェックの結果)をリダイレクト先で表示
             ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
  
             return "redirect:/rental/add";
@@ -128,72 +206,101 @@ public class RentalManageController {
     }
 
     /*　貸出編集画面 */
+    //{id}はパス変数として受け取る。特定のIDを持つレンタルの編集画面を表示するために使用。
     @GetMapping("/rental/{id}/edit")
+    //@PathVariableアノテーションを使用して、URLからidパラメーターを受け取る。
     public String edit(@PathVariable("id") String id, Model model, @RequestParam(name = "errorMessage", required = false) String errorMessage) {
+        //全件取得
         List<RentalManage> rentalManageList = this.rentalManageService.findAll();
- 
         List<Account> accounts = this.accountService.findAll();
         List<Stock> stockList = this.stockService.findAll();
- 
+        //modelに情報を追加し、必要に応じて列挙型を属性として取得
         model.addAttribute("accounts", accounts);
         model.addAttribute("stockList", stockList);
         model.addAttribute("rentalStatus", RentalStatus.values());
- 
         model.addAttribute("rentalManageList", rentalManageList);
         model.addAttribute("rentalStockStatus", StockStatus.values());
- 
+        //エラーメッセージがある場合はそのメッセージをmodelに追加
         if (errorMessage != null) {
             model.addAttribute("errorMessage", errorMessage);
         }
-
+        /*containsAttributeメソッドは、モデルに指定された属性が含まれているかどうかを確認するために使用。
+         *含まれていなければ、新しいRentalManageDtoオブジェクトを作成するための条件が成立する。*/
         if (!model.containsAttribute("rentalManageDto")) {
+            //新しくrentalManageDtoを作成
             RentalManageDto rentalManageDto = new RentalManageDto();
+            //パス変数から取得した文字列形式のIDをLong型に変換
             Long idLong = Long.parseLong(id);
+            //指定されたIDに対応するRentalManageオブジェクトをデータベースから取得
             RentalManage rentalManage = this.rentalManageService.findById(idLong);
 
- 
+            /*取得したRentalManageオブジェクトから必要な情報を取り出し、RentalManageDtoオブジェクトに設定
+             * 1.rentalManage.getAccount()は、RentalManageエンティティに関連付けられたAccountエンティティを取得。
+               2.getEmployeeId()は、AccountエンティティからemployeeIdを取得。
+               3.取得したemployeeIdは、RentalManageDtoの対応するフィールドであるemployeeIdにセット。
+            */
             rentalManageDto.setEmployeeId(rentalManage.getAccount().getEmployeeId());
- 
             rentalManageDto.setId(rentalManage.getId());
             rentalManageDto.setExpectedRentalOn(rentalManage.getExpectedRentalOn());
             rentalManageDto.setExpectedReturnOn(rentalManage.getExpectedReturnOn());
             rentalManageDto.setStatus(rentalManage.getStatus());
             rentalManageDto.setStockId(rentalManage.getStock().getId());
- 
+            //RentalManageDtoオブジェクトをモデルに"rentalManageDto"という属性名で追加
             model.addAttribute("rentalManageDto", rentalManageDto);
         }
  
         return "rental/edit";
     }
-
-
-
+    //貸出可否チェック（更新時）
+    public String rentalCheck(RentalManageDto rentalManageDto, String id, Long rentalId) {
+        List<RentalManage> rentalAvailable = this.rentalManageService.findByStockIdAndStatusIn(id, rentalId);
+        if (rentalAvailable != null) {
+            // ループ処理
+            for (RentalManage rentalManage : rentalAvailable) {
+                if (rentalManage.getExpectedReturnOn().after(rentalManageDto.getExpectedRentalOn())
+                        && rentalManage.getExpectedRentalOn().before(rentalManageDto.getExpectedReturnOn())) {
+                    return "貸出期間が重複しています";
+                }
+            }
+            return null;
+        } else {
+            return null;
+        }
+    }
+    //ここまで
     
     @PostMapping("/rental/{id}/edit")
     public String update(@PathVariable("id") Long id, @Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, Model model) {
         try {
+            //追加（5/17）
+            String errorMessage = checkInventoryStatus(rentalManageDto.getStockId());
+                if (errorMessage != null) {
+                    result.addError(new FieldError("rentalManageDto", "stockId", errorMessage));
+            }
+            //追加（5/16）
+            RentalManage rentalManage = this.rentalManageService.findById(id);
+            String DateError = this.rentalCheck(rentalManageDto,rentalManageDto.getStockId(),rentalManageDto.getId());
+            if (DateError != null) {
+                // rentalManageDtoからexpectedRentalOnとexpectedReturnOnの値を取得して、FieldErrorオブジェクトに追加する
+                result.addError(new FieldError("rentalManageDto", "expectedRentalOn", DateError));
+                result.addError(new FieldError("rentalManageDto", "expectedReturnOn", DateError));
+            }
+            //ここまで
+
             // バリデーションエラーチェック
             if (result.hasErrors()) {
                 model.addAttribute("errorMessage", "入力内容にエラーがあります");
                 // バリデーションエラーがある場合は編集画面に戻る
-                List<Stock> stockList = this.stockService.findStockAvailableAll();
-                List<Account> accounts = this.accountService.findAll();
-                model.addAttribute("accounts", accounts);
-                model.addAttribute("stockList", stockList);
-                model.addAttribute("rentalStatus", RentalStatus.values());
+                addCommonAttributes(model);
                 return "rental/edit";
             }
     
             // 貸出情報を取得
-            RentalManage rentalManage = this.rentalManageService.findById(id);
+            rentalManage = this.rentalManageService.findById(id);
             if (rentalManage == null) {
                 model.addAttribute("errorMessage", "指定された貸出情報が見つかりません");
                 // 貸出情報が見つからない場合は編集画面に戻る
-                List<Stock> stockList = this.stockService.findStockAvailableAll();
-                List<Account> accounts = this.accountService.findAll();
-                model.addAttribute("accounts", accounts);
-                model.addAttribute("stockList", stockList);
-                model.addAttribute("rentalStatus", RentalStatus.values());
+                addCommonAttributes(model);
                 return "rental/edit";
             }
     
@@ -202,52 +309,65 @@ public class RentalManageController {
             if (statusErrorMessage != null) {
                 model.addAttribute("errorMessage", statusErrorMessage);
                 // ステータスが無効な場合は編集画面に戻る
-                List<Stock> stockList = this.stockService.findStockAvailableAll();
-                List<Account> accounts = this.accountService.findAll();
-                model.addAttribute("accounts", accounts);
-                model.addAttribute("stockList", stockList);
-                model.addAttribute("rentalStatus", RentalStatus.values());
+                addCommonAttributes(model);
                 return "rental/edit";
             }
-    
-            // 貸出予定日のバリデーションチェック
-            if (rentalManage.getStatus() == RentalStatus.RENT_WAIT.getValue() &&
-                rentalManageDto.getStatus() == RentalStatus.RENTAlING.getValue()){
-            if (!rentalManageDto.isValidRentalDate()) {
-       
-                model.addAttribute("errorMessage", "貸出予定日は現在の日付に設定してください");
-                List<Stock> stockList = this.stockService.findStockAvailableAll();
-                List<Account> accounts = this.accountService.findAll();
-                model.addAttribute("accounts", accounts);
-                model.addAttribute("stockList", stockList);
-                model.addAttribute("rentalStatus", RentalStatus.values());
+
+            //貸出中・返却済み時の貸出日のバリデーションチェック（5/20）
+            // 修正後のコード
+            String dateErrorMessage = isValidDate(rentalManageDto, rentalManage);
+            if (dateErrorMessage != null) {
+                //result.addError(new FieldError("rentalManageDto", "status", dateErrorMessage));
+                model.addAttribute("errorMessage", dateErrorMessage);
+                // ステータスが無効な場合は編集画面に戻る
+                addCommonAttributes(model);
                 return "rental/edit";
-                }
-            //返却予定日のバリデーションチェック
-            }else if (rentalManage.getStatus() == RentalStatus.RENTAlING.getValue() &&
-                rentalManageDto.getStatus() == RentalStatus.RETURNED.getValue()) {
-            if(!rentalManageDto.isValidReturnDate()) {
-        
-                model.addAttribute("errorMessage", "返却予定日は現在の日付に設定してください");
-                List<Stock> stockList = this.stockService.findStockAvailableAll();
-                List<Account> accounts = this.accountService.findAll();
-                model.addAttribute("accounts", accounts);
-                model.addAttribute("stockList", stockList);
-                model.addAttribute("rentalStatus", RentalStatus.values());
-                return "rental/edit";
-                }
             }
+
             // 更新処理
             this.rentalManageService.update(id, rentalManageDto);
             return "redirect:/rental/index";
-            } catch (Exception e) {
+        } catch (Exception e) {
             // エラーが発生した場合の処理
             log.error("更新処理中にエラーが発生しました: " + e.getMessage());
             model.addAttribute("errorMessage", "更新処理中にエラーが発生しました");
             return "rental/edit";
         }
     }
+
+    public String isValidDate(RentalManageDto rentalManageDto, RentalManage rentalManage) {
+        LocalDate currentDate = LocalDate.now(ZoneId.of("Asia/Tokyo")); // 現在の日付を取得。おそらく貸出開始日のタイムゾーンがずれている
     
+        //rentalDateとreturnDateをLocalDateに変換
+        LocalDate rentalDate = rentalManageDto.getExpectedRentalOn().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+        LocalDate returnDate = rentalManageDto.getExpectedReturnOn().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
     
-} 
-  
+        Integer oldStatus = rentalManage.getStatus();
+        Integer newStatus = rentalManageDto.getStatus();
+    
+        if (oldStatus == 0 && newStatus == 1) {
+            if (!rentalDate.equals(currentDate)) {
+                return "貸出予定日は現在の日付で登録して下さい";
+            }
+        }
+        if (oldStatus == 1 && newStatus == 2) {
+            if (!returnDate.equals(currentDate)) {
+                return "返却予定日は現在の日付で登録して下さい";
+            }
+        }
+        if (rentalDate.isAfter(returnDate)) {
+            return "貸出予定日は返却予定日よりも前に設定してください";
+        }
+        return null;
+    }
+
+    //エラー時の表示遷移に
+    private void addCommonAttributes(Model model) {
+        List<Stock> stockList = this.stockService.findStockAvailableAll();
+        List<Account> accounts = this.accountService.findAll();
+        model.addAttribute("accounts", accounts);
+        model.addAttribute("stockList", stockList);
+        model.addAttribute("rentalStatus", RentalStatus.values());
+    } 
+}
+

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -27,13 +27,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import jakarta.validation.Valid;
 
-
 //追加インポート
 import org.springframework.web.bind.annotation.RequestParam;//(5/14)
-import java.time.LocalDate;
-import java.time.ZoneId;
-
-
 
 /**
  * 貸出管理関連クラスß
@@ -42,27 +37,27 @@ import java.time.ZoneId;
 @Controller
 public class RentalManageController {
 
-    //final修飾子で変数が初期化された後の変更を拒否
-    //フィールド宣言（AccountServiceなど）をして変数を定義（accountService）
+    // final修飾子で変数が初期化された後の変更を拒否
+    // フィールド宣言（AccountServiceなど）をして変数を定義（accountService）
     private final AccountService accountService;
     private final RentalManageService rentalManageService;
     private final StockService stockService;
 
-    //インスタンス生成の際に呼び出されるコンストラクタの定義
-    /*AutowiredによってSpringFrameworkがDI（Dependency Injection）を行う。
-     *DIによって、クラス間の依存関係を明示的にせずに、それらの依存関係を容易に変更したりすることができる。
-     *要は下記3つのインスタンスを、具体的な実装関係なく参照することができる。
-     *　→参照するクラスの実装を変えても、このクラスのコードは変えなくてもいい。柔軟性の高いコーディング。
-    */
+    // インスタンス生成の際に呼び出されるコンストラクタの定義
+    /*
+     * AutowiredによってSpringFrameworkがDI（Dependency Injection）を行う。
+     * DIによって、クラス間の依存関係を明示的にせずに、それらの依存関係を容易に変更したりすることができる。
+     * 要は下記3つのインスタンスを、具体的な実装関係なく参照することができる。
+     * →参照するクラスの実装を変えても、このクラスのコードは変えなくてもいい。柔軟性の高いコーディング。
+     */
     @Autowired
     public RentalManageController(
-        //AccountServiceというクラスのaccountServiceというインスタンスを参照。
-        AccountService accountService, 
-        RentalManageService rentalManageService, 
-        StockService stockService
-    ) {
-        //コンストラクターで受け取ったaccountServiceをRentalManageControllerクラスのインスタンス変数に格納する。
-        //this.accountService→このクラスでの変数accountServiceは、右辺のaccountService(上で参照したのと同じ)と同じものです、と定義。
+            // AccountServiceというクラスのaccountServiceというインスタンスを参照。
+            AccountService accountService,
+            RentalManageService rentalManageService,
+            StockService stockService) {
+        // コンストラクターで受け取ったaccountServiceをRentalManageControllerクラスのインスタンス変数に格納する。
+        // this.accountService→このクラスでの変数accountServiceは、右辺のaccountService(上で参照したのと同じ)と同じものです、と定義。
         this.accountService = accountService;
         this.rentalManageService = rentalManageService;
         this.stockService = stockService;
@@ -70,55 +65,58 @@ public class RentalManageController {
 
     /**
      * 貸出一覧画面初期表示
-     * @param model　//Modelオブジェクトが引数として渡されています。SpringMVCが提供するモデルオブジェクト。
+     * 
+     * @param model //Modelオブジェクトが引数として渡されています。SpringMVCが提供するモデルオブジェクト。
      * @return //メソッドが返す値や戻り値に関する情報を提供するために使用される。つまりどういうこと？
      */
-    //「/rental/index」というURI(貸出一覧画面)へのGETリクエストがこのメソッドに送信されると、そのリクエストを処理するためにこのメソッドが呼び出される。
+    // 「/rental/index」というURI(貸出一覧画面)へのGETリクエストがこのメソッドに送信されると、そのリクエストを処理するためにこのメソッドが呼び出される。
     @GetMapping("/rental/index")
-    //メソッド名がindex、引数名がmodel。
+    // メソッド名がindex、引数名がmodel。
     public String index(Model model) {
         // 貸出管理テーブルから全件取得
-        //取得した貸出管理情報は、変数RentalManageList に代入されており、この変数には全ての貸出管理情報が含まれる。
-        //this.rentalManageServiceサービスについては上述
+        // 取得した貸出管理情報は、変数RentalManageList に代入されており、この変数には全ての貸出管理情報が含まれる。
+        // this.rentalManageServiceサービスについては上述
         List<RentalManage> RentalManageList = this.rentalManageService.findAll();
         // 貸出一覧画面に渡すデータをmodelに追加
-        //addAttributeは属性追加のメソッド。()内に名前と、属性として追加する変数（一行上で定義）を記述する。
+        // addAttributeは属性追加のメソッド。()内に名前と、属性として追加する変数（一行上で定義）を記述する。
         model.addAttribute("rentalManageList", RentalManageList);
         // 貸出一覧画面に遷移
-        //rental/indexを返している。引数が文字列だが、これはパス名を指している。
-        //この行を使うことで、このメソッドが実行された後に、指定されたビュー(rental/index)に遷移することができる。
+        // rental/indexを返している。引数が文字列だが、これはパス名を指している。
+        // この行を使うことで、このメソッドが実行された後に、指定されたビュー(rental/index)に遷移することができる。
         return "rental/index";
     }
 
-    //Springのアノテーションを使用。GETリクエストが "/rental/add" というURLに対応。
-    //アノテーション…
+    // Springのアノテーションを使用。GETリクエストが "/rental/add" というURLに対応。
+    // アノテーション…
     @GetMapping("/rental/add")
-    //引数のModelオブジェクトは、ビューにデータを渡すためのもの。
+    // 引数のModelオブジェクトは、ビューにデータを渡すためのもの。
     public String add(Model model) {
-        //Stock・Accountクラスのインスタンスリストを取得。変数名stockList・accounts。
-        //本クラスで定義したstockService・accountServiceの全ての情報を取得
-        List <Stock> stockList = this.stockService.findAll();
-        List <Account> accounts = this.accountService.findAll();
-        //モデルに情報のリストを追加する。
-        //addAttribute()はモデルに属性を追加するメソッド。属性は“名前”と値のペアで構成。
-        //上記より、ビュー（HTMLテンプレート）において${accounts}の様な仕方でこれらの属性にアクセスが可能。
+        // Stock・Accountクラスのインスタンスリストを取得。変数名stockList・accounts。
+        // 本クラスで定義したstockService・accountServiceの全ての情報を取得
+        List<Stock> stockList = this.stockService.findAll();
+        List<Account> accounts = this.accountService.findAll();
+        // モデルに情報のリストを追加する。
+        // addAttribute()はモデルに属性を追加するメソッド。属性は“名前”と値のペアで構成。
+        // 上記より、ビュー（HTMLテンプレート）において${accounts}の様な仕方でこれらの属性にアクセスが可能。
         model.addAttribute("accounts", accounts);
         model.addAttribute("stockList", stockList);
-        /*RentalStatus.values()について。
-        //RentalStatusクラスの列挙型を全権取得している。
-        //Javaの列挙型(enum)は、複数の定数(値)を定義するための特殊な型。
-        //列挙型の使用で、関連する定数(値)をグループ化し、プログラム内で使いやすくなる。
-        今回は、
-        public enum RentalStatus implements Values {
-            RENT_WAIT(0, "貸出待ち")
-            , RENTAlING(1, "貸出中")
-            , RETURNED(2, "返却済み")
-            , CANCELED(3, "キャンセル");    
-        }
-        */
+        /*
+         * RentalStatus.values()について。
+         * //RentalStatusクラスの列挙型を全権取得している。
+         * //Javaの列挙型(enum)は、複数の定数(値)を定義するための特殊な型。
+         * //列挙型の使用で、関連する定数(値)をグループ化し、プログラム内で使いやすくなる。
+         * 今回は、
+         * public enum RentalStatus implements Values {
+         * RENT_WAIT(0, "貸出待ち")
+         * , RENTAlING(1, "貸出中")
+         * , RETURNED(2, "返却済み")
+         * , CANCELED(3, "キャンセル");
+         * }
+         */
         model.addAttribute("rentalStatus", RentalStatus.values());
-        /*モデルに"rentalManageDto"という名前の属性が含まれていない場合は、新しいRentalManageDtoオブジェクトをモデルに追加する。
-        　上記は、フォームを初期化するために使用される（？）。
+        /*
+         * モデルに"rentalManageDto"という名前の属性が含まれていない場合は、新しいRentalManageDtoオブジェクトをモデルに追加する。
+         * 上記は、フォームを初期化するために使用される（？）。
          */
         if (!model.containsAttribute("rentalManageDto")) {
             model.addAttribute("rentalManageDto", new RentalManageDto());
@@ -129,164 +127,117 @@ public class RentalManageController {
             model.addAttribute("rentalManageDto", new RentalManageDto());
         }
 
-
-
         return "rental/add";
     }
 
-    //利用可否チェック
-    private String checkInventoryStatus(String id) {
-        // 在庫ステータスを確認するロジックを記述
-        Stock stock = this.stockService.findById(id);
-            if (stock.getStatus() == 0) {
-                return null; // 利用可の場合はエラーメッセージなし
-            } else {
-                return "この本は利用できません"; // 利用不可の場合はエラーメッセージを返す
-            }
-    }
-
-    //貸出可否チェック（登録時）
-    public String rentalCheck(RentalManageDto rentalManageDto, String id) {
-        List<RentalManage> rentalAvailable = this.rentalManageService.findByStockIdAndStatusIn(id);
-        if (rentalAvailable != null) {
-            // ループ処理
-            for (RentalManage rentalManage : rentalAvailable) {
-                if (rentalManage.getExpectedReturnOn().after(rentalManageDto.getExpectedRentalOn())
-                        && rentalManage.getExpectedRentalOn().before(rentalManageDto.getExpectedReturnOn())) {
-                    return "貸出期間が重複しています";
-                }
-            }
-            return null;
-        } else {
-            return null;
-        }
-    }
-
-    //POSTリクエストが "/rental/add" というURLに対応。
+    // POSTリクエストが "/rental/add" というURLに対応。
     @PostMapping("/rental/add")
-    /*HTTP POSTリクエストが "/rental/add" に送信されたときに呼び出される。
-    @Validアノテーションは、rentalManageDtoオブジェクトのバリデーションを有効にする
-    BindingResultオブジェクトはバインディング結果を保持する。
-    @ModelAttributeアノテーションは、リクエストパラメーターをJavaオブジェクトにバインドします。*/
-    public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, RedirectAttributes ra) {
+    /*
+     * HTTP POSTリクエストが "/rental/add" に送信されたときに呼び出される。
+     * 
+     * @Validアノテーションは、rentalManageDtoオブジェクトのバリデーションを有効にする
+     * BindingResultオブジェクトはバインディング結果を保持する。
+     * 
+     * @ModelAttributeアノテーションは、リクエストパラメーターをJavaオブジェクトにバインドします。
+     */
+    public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result,
+            RedirectAttributes ra, Model model) {
         try {
-            //ここから追加です（5/17）
-            String errorMessage = checkInventoryStatus(rentalManageDto.getStockId());
-                if (errorMessage != null) {
-                    result.addError(new FieldError("rentalManageDto", "stockId", errorMessage));
-            }
-            //ここから追加です（5/16）
-            String DateError = this.rentalCheck(rentalManageDto,rentalManageDto.getStockId());
-                if (DateError != null) {
-                    // rentalManageDtoからexpectedRentalOnとexpectedReturnOnの値を取得して、FieldErrorオブジェクトに追加する
-                    result.addError(new FieldError("rentalManageDto", "expectedRentalOn", DateError));
-                    result.addError(new FieldError("rentalManageDto", "expectedReturnOn", DateError));
-                }
-            //ここまで
 
-            //バリデーションエラーが発生した場合、例外がスロー。
+            // バリデーションチェック
             if (result.hasErrors()) {
                 throw new Exception("Validation error.");
             }
 
+            // 利用可否チェック 追加（5/17）
+            String errorMessage = this.checkInventoryStatus(rentalManageDto.getStockId());
+            if (errorMessage != null) {
+                result.addError(new FieldError("rentalManageDto", "stockId", errorMessage));
+                addCommonAttributes(model);
+                return "rental/add";
+            }
+            // 貸出可否チェック 追加（5/16）
+            String DateError = rentalManageDto.rentalCheck(rentalManageService, rentalManageDto,
+                    rentalManageDto.getStockId());
+            if (DateError != null) {
+                // rentalManageDtoからexpectedRentalOnとexpectedReturnOnの値を取得して、FieldErrorオブジェクトに追加する
+                result.addError(new FieldError("rentalManageDto", "expectedRentalOn", DateError));
+                result.addError(new FieldError("rentalManageDto", "expectedReturnOn", DateError));
+            }
+            // ここまで
             // 登録処理。RentalMangeServiceを使用し、rentalManageDtoオブジェクトを保存する（返す？）
             this.rentalManageService.save(rentalManageDto);
- 
+
             return "redirect:/rental/index";
         } catch (Exception e) {
             log.error(e.getMessage());
-            /*リダイレクト先のビューにデータを渡すためのフラッシュ属性"rentalManageDto"を追加。
-            フラッシュ属性...リダイレクト先のリクエスト「のみ」で利用可能であり、セッションに保存された後に自動的に削除される */
+            /*
+             * リダイレクト先のビューにデータを渡すためのフラッシュ属性"rentalManageDto"を追加。
+             * フラッシュ属性...リダイレクト先のリクエスト「のみ」で利用可能であり、セッションに保存された後に自動的に削除される
+             */
             ra.addFlashAttribute("rentalManageDto", rentalManageDto);
-            //(バリデーションチェックの結果)をリダイレクト先で表示
+            // (バリデーションチェックの結果)をリダイレクト先で表示
             ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
- 
+
             return "redirect:/rental/add";
         }
     }
 
-    /*　貸出編集画面 */
-    //{id}はパス変数として受け取る。特定のIDを持つレンタルの編集画面を表示するために使用。
+    /* 貸出編集画面 */
+    // {id}はパス変数として受け取る。特定のIDを持つレンタルの編集画面を表示するために使用。
     @GetMapping("/rental/{id}/edit")
-    //@PathVariableアノテーションを使用して、URLからidパラメーターを受け取る。
-    public String edit(@PathVariable("id") String id, Model model, @RequestParam(name = "errorMessage", required = false) String errorMessage) {
-        //全件取得
+    // @PathVariableアノテーションを使用して、URLからidパラメーターを受け取る。
+    public String edit(@PathVariable("id") String id, Model model,
+            @RequestParam(name = "errorMessage", required = false) String errorMessage) {
+        // 全件取得
         List<RentalManage> rentalManageList = this.rentalManageService.findAll();
         List<Account> accounts = this.accountService.findAll();
         List<Stock> stockList = this.stockService.findAll();
-        //modelに情報を追加し、必要に応じて列挙型を属性として取得
+        // modelに情報を追加し、必要に応じて列挙型を属性として取得
         model.addAttribute("accounts", accounts);
         model.addAttribute("stockList", stockList);
         model.addAttribute("rentalStatus", RentalStatus.values());
         model.addAttribute("rentalManageList", rentalManageList);
         model.addAttribute("rentalStockStatus", StockStatus.values());
-        //エラーメッセージがある場合はそのメッセージをmodelに追加
+        // エラーメッセージがある場合はそのメッセージをmodelに追加
         if (errorMessage != null) {
             model.addAttribute("errorMessage", errorMessage);
         }
-        /*containsAttributeメソッドは、モデルに指定された属性が含まれているかどうかを確認するために使用。
-         *含まれていなければ、新しいRentalManageDtoオブジェクトを作成するための条件が成立する。*/
+        /*
+         * containsAttributeメソッドは、モデルに指定された属性が含まれているかどうかを確認するために使用。
+         * 含まれていなければ、新しいRentalManageDtoオブジェクトを作成するための条件が成立する。
+         */
         if (!model.containsAttribute("rentalManageDto")) {
-            //新しくrentalManageDtoを作成
+            // 新しくrentalManageDtoを作成
             RentalManageDto rentalManageDto = new RentalManageDto();
-            //パス変数から取得した文字列形式のIDをLong型に変換
+            // パス変数から取得した文字列形式のIDをLong型に変換
             Long idLong = Long.parseLong(id);
-            //指定されたIDに対応するRentalManageオブジェクトをデータベースから取得
+            // 指定されたIDに対応するRentalManageオブジェクトをデータベースから取得
             RentalManage rentalManage = this.rentalManageService.findById(idLong);
 
-            /*取得したRentalManageオブジェクトから必要な情報を取り出し、RentalManageDtoオブジェクトに設定
+            /*
+             * 取得したRentalManageオブジェクトから必要な情報を取り出し、RentalManageDtoオブジェクトに設定
              * 1.rentalManage.getAccount()は、RentalManageエンティティに関連付けられたAccountエンティティを取得。
-               2.getEmployeeId()は、AccountエンティティからemployeeIdを取得。
-               3.取得したemployeeIdは、RentalManageDtoの対応するフィールドであるemployeeIdにセット。
-            */
+             * 2.getEmployeeId()は、AccountエンティティからemployeeIdを取得。
+             * 3.取得したemployeeIdは、RentalManageDtoの対応するフィールドであるemployeeIdにセット。
+             */
             rentalManageDto.setEmployeeId(rentalManage.getAccount().getEmployeeId());
             rentalManageDto.setId(rentalManage.getId());
             rentalManageDto.setExpectedRentalOn(rentalManage.getExpectedRentalOn());
             rentalManageDto.setExpectedReturnOn(rentalManage.getExpectedReturnOn());
             rentalManageDto.setStatus(rentalManage.getStatus());
             rentalManageDto.setStockId(rentalManage.getStock().getId());
-            //RentalManageDtoオブジェクトをモデルに"rentalManageDto"という属性名で追加
+            // RentalManageDtoオブジェクトをモデルに"rentalManageDto"という属性名で追加
             model.addAttribute("rentalManageDto", rentalManageDto);
         }
- 
+
         return "rental/edit";
     }
-    //貸出可否チェック（更新時）
-    public String rentalCheck(RentalManageDto rentalManageDto, String id, Long rentalId) {
-        List<RentalManage> rentalAvailable = this.rentalManageService.findByStockIdAndStatusIn(id, rentalId);
-        if (rentalAvailable != null) {
-            // ループ処理
-            for (RentalManage rentalManage : rentalAvailable) {
-                if (rentalManage.getExpectedReturnOn().after(rentalManageDto.getExpectedRentalOn())
-                        && rentalManage.getExpectedRentalOn().before(rentalManageDto.getExpectedReturnOn())) {
-                    return "貸出期間が重複しています";
-                }
-            }
-            return null;
-        } else {
-            return null;
-        }
-    }
-    //ここまで
-    
-    @PostMapping("/rental/{id}/edit")
-    public String update(@PathVariable("id") Long id, @Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, Model model) {
-        try {
-            //追加（5/17）
-            String errorMessage = checkInventoryStatus(rentalManageDto.getStockId());
-                if (errorMessage != null) {
-                    result.addError(new FieldError("rentalManageDto", "stockId", errorMessage));
-            }
-            //追加（5/16）
-            RentalManage rentalManage = this.rentalManageService.findById(id);
-            String DateError = this.rentalCheck(rentalManageDto,rentalManageDto.getStockId(),rentalManageDto.getId());
-            if (DateError != null) {
-                // rentalManageDtoからexpectedRentalOnとexpectedReturnOnの値を取得して、FieldErrorオブジェクトに追加する
-                result.addError(new FieldError("rentalManageDto", "expectedRentalOn", DateError));
-                result.addError(new FieldError("rentalManageDto", "expectedReturnOn", DateError));
-            }
-            //ここまで
 
+    @PostMapping("/rental/{id}/edit")
+    public String update(@PathVariable("id") Long id, @Valid @ModelAttribute RentalManageDto rentalManageDto,
+            BindingResult result, Model model) {
+        try {
             // バリデーションエラーチェック
             if (result.hasErrors()) {
                 model.addAttribute("errorMessage", "入力内容にエラーがあります");
@@ -294,36 +245,41 @@ public class RentalManageController {
                 addCommonAttributes(model);
                 return "rental/edit";
             }
-    
-            // 貸出情報を取得
-            rentalManage = this.rentalManageService.findById(id);
-            if (rentalManage == null) {
-                model.addAttribute("errorMessage", "指定された貸出情報が見つかりません");
-                // 貸出情報が見つからない場合は編集画面に戻る
-                addCommonAttributes(model);
-                return "rental/edit";
-            }
-    
             // 貸出情報のステータスをチェック
+            RentalManage rentalManage = this.rentalManageService.findById(id);
             String statusErrorMessage = rentalManageDto.isValidStatus(rentalManage.getStatus());
             if (statusErrorMessage != null) {
                 model.addAttribute("errorMessage", statusErrorMessage);
-                // ステータスが無効な場合は編集画面に戻る
+                // 無効な変更をした場合は編集画面に戻る
                 addCommonAttributes(model);
                 return "rental/edit";
             }
-
-            //貸出中・返却済み時の貸出日のバリデーションチェック（5/20）
-            // 修正後のコード
-            String dateErrorMessage = isValidDate(rentalManageDto, rentalManage);
+            // 日付チェック（5/20）
+            String dateErrorMessage = rentalManageDto.isValidDate(rentalManageDto, rentalManage);
             if (dateErrorMessage != null) {
-                //result.addError(new FieldError("rentalManageDto", "status", dateErrorMessage));
                 model.addAttribute("errorMessage", dateErrorMessage);
-                // ステータスが無効な場合は編集画面に戻る
+                // 日付が現在日になっていない場合は編集画面に戻る
                 addCommonAttributes(model);
                 return "rental/edit";
             }
-
+            // 利用可否チェック 追加（5/17）
+            String errorMessage = this.checkInventoryStatus(rentalManageDto.getStockId());
+            if (errorMessage != null) {
+                result.addError(new FieldError("rentalManageDto", "stockId", errorMessage));
+                // 書籍が利用不可の場合は編集画面に戻る
+                addCommonAttributes(model);
+                return "rental/edit";
+            }
+            // 貸出可否チェック 追加（5/16）
+            String DateError = rentalManageDto.rentalCheck(rentalManageService, rentalManageDto,
+                    rentalManageDto.getStockId(), rentalManageDto.getId());
+            if (DateError != null) {
+                result.addError(new FieldError("rentalManageDto", "expectedRentalOn", DateError));
+                result.addError(new FieldError("rentalManageDto", "expectedReturnOn", DateError));
+                // 貸出期間に重複があった場合は編集画面に戻る
+                addCommonAttributes(model);
+                return "rental/edit";
+            }
             // 更新処理
             this.rentalManageService.update(id, rentalManageDto);
             return "redirect:/rental/index";
@@ -335,39 +291,22 @@ public class RentalManageController {
         }
     }
 
-    public String isValidDate(RentalManageDto rentalManageDto, RentalManage rentalManage) {
-        LocalDate currentDate = LocalDate.now(ZoneId.of("Asia/Tokyo")); // 現在の日付を取得。おそらく貸出開始日のタイムゾーンがずれている
-    
-        //rentalDateとreturnDateをLocalDateに変換
-        LocalDate rentalDate = rentalManageDto.getExpectedRentalOn().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
-        LocalDate returnDate = rentalManageDto.getExpectedReturnOn().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
-    
-        Integer oldStatus = rentalManage.getStatus();
-        Integer newStatus = rentalManageDto.getStatus();
-    
-        if (oldStatus == 0 && newStatus == 1) {
-            if (!rentalDate.equals(currentDate)) {
-                return "貸出予定日は現在の日付で登録して下さい";
-            }
+    // 利用可否チェック
+    private String checkInventoryStatus(String id) {
+        Stock stock = this.stockService.findById(id);
+        if (stock.getStatus() != StockStatus.RENT_AVAILABLE.getValue()) {// 修正いたしました（5/21）
+            return "この本は利用できません"; // 利用不可の場合はエラーメッセージを返す
+        } else {
+            return null; // 利用可の場合はエラーメッセージなし
         }
-        if (oldStatus == 1 && newStatus == 2) {
-            if (!returnDate.equals(currentDate)) {
-                return "返却予定日は現在の日付で登録して下さい";
-            }
-        }
-        if (rentalDate.isAfter(returnDate)) {
-            return "貸出予定日は返却予定日よりも前に設定してください";
-        }
-        return null;
     }
 
-    //エラー時の表示遷移に
+    // エラー時の表示遷移に
     private void addCommonAttributes(Model model) {
         List<Stock> stockList = this.stockService.findStockAvailableAll();
         List<Account> accounts = this.accountService.findAll();
         model.addAttribute("accounts", accounts);
         model.addAttribute("stockList", stockList);
         model.addAttribute("rentalStatus", RentalStatus.values());
-    } 
+    }
 }
-

--- a/src/main/java/jp/co/metateam/library/model/RentalManage.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManage.java
@@ -94,7 +94,7 @@ public class RentalManage {
     public Account getAccount() {
         return account;
     }
-    
+
     /** Setters */
 
     public void setId(Long id) {

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -1,9 +1,8 @@
 package jp.co.metateam.library.model;
 
 import java.sql.Timestamp;
-/* import java.text.SimpleDateFormat;
 import java.time.LocalDate;
-import java.time.ZoneId; */
+import java.time.ZoneId;
 import java.util.Date;
 
 import org.springframework.format.annotation.DateTimeFormat;
@@ -14,9 +13,10 @@ import jp.co.metateam.library.values.RentalStatus;
 import lombok.Getter;
 import lombok.Setter;
 
-/* import jp.co.metateam.library.service.RentalManageService;
-import jp.co.metateam.library.service.StockService; */
+import jp.co.metateam.library.service.RentalManageService;
+import java.util.List;
 
+//import jp.co.metateam.library.service.StockService;
 
 /**
  * 貸出管理DTO
@@ -27,21 +27,21 @@ public class RentalManageDto {
 
     private Long id;
 
-    @NotEmpty(message="在庫管理番号は必須です")
+    @NotEmpty(message = "在庫管理番号は必須です")
     private String stockId;
 
-    @NotEmpty(message="社員番号は必須です")
+    @NotEmpty(message = "社員番号は必須です")
     private String employeeId;
 
-    @NotNull(message="貸出ステータスは必須です")
+    @NotNull(message = "貸出ステータスは必須です")
     private Integer status;
 
-    @DateTimeFormat(pattern="yyyy-MM-dd")
-    @NotNull(message="貸出予定日は必須です")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @NotNull(message = "貸出予定日は必須です")
     private Date expectedRentalOn;
 
-    @DateTimeFormat(pattern="yyyy-MM-dd")
-    @NotNull(message="返却予定日は必須です")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @NotNull(message = "返却予定日は必須です")
     private Date expectedReturnOn;
 
     private Timestamp rentaledAt;
@@ -54,8 +54,8 @@ public class RentalManageDto {
 
     private Account account;
 
-    ////加えました（5/13）
-    private Integer newStatus;  
+    //// 加えました（5/13）
+    private Integer newStatus;
 
     // getStatusメソッドを追加
     public Integer getStatus() {
@@ -65,105 +65,105 @@ public class RentalManageDto {
     // getNewStatusメソッドを追加
     public Integer getNewStatus() {
         return this.newStatus;
-    }    
-    ////ここまでです
-
-    ////加えました（5/14） 
-        // 貸出状態が有効かどうかをチェックするメソッド
-            public String isValidStatus(Integer previousStatus) {
-                if(previousStatus == RentalStatus.RENT_WAIT.getValue() && this.status == RentalStatus.RETURNED.getValue()){
-                    return "貸出ステータスは「貸出待ち」から「返却済み」に変更できません";
-                }else if(previousStatus == RentalStatus.RENTAlING.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()){
-                    return "貸出ステータスは「貸出中」から「貸出待ち」に変更できません";
-                }else if(previousStatus == RentalStatus.RENTAlING.getValue() && this.status == RentalStatus.CANCELED.getValue()){
-                    return "貸出ステータスは「貸出中」から「キャンセル」に変更できません";
-                }else if(previousStatus == RentalStatus.RETURNED.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()){
-                    return "貸出ステータスは「返却済み」から「貸出待ち」に変更できません";
-                }else if(previousStatus == RentalStatus.RETURNED.getValue() && this.status == RentalStatus.RENTAlING.getValue()){
-                     return "貸出ステータスは「返却済み」から「貸出中」に変更できません";
-                }else if(previousStatus == RentalStatus.RETURNED.getValue() && this.status == RentalStatus.CANCELED.getValue()){
-                    return "貸出ステータスは「返却済み」から「キャンセル」に変更できません";
-                }else if(previousStatus == RentalStatus.CANCELED.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()){
-                    return "貸出ステータスは「キャンセル」から「貸出待ち」に変更できません";
-                }else if(previousStatus == RentalStatus.CANCELED.getValue() && this.status == RentalStatus.RENTAlING.getValue()){
-                    return "貸出ステータスは「キャンセル」から「貸出中」に変更できません";
-                }else if(previousStatus == RentalStatus.CANCELED.getValue() && this.status == RentalStatus.RETURNED.getValue()){
-                    return "貸出ステータスは「キャンセル」から「返却済み」に変更できません";
-                }
-                return null;
-            }
-
-            //Controller　→　Dto移行用
-/*             //利用可日チェック
-            private StockService stockService;
-            public String checkInventoryStatus(String id) {
-                // 在庫ステータスを確認するロジックを記述
-                Stock stock = stockService.findById(id);
-                    if (stock.getStatus() == 0) {
-                        return null; // 利用可の場合はエラーメッセージなし
-                    } else {
-                        return "この本は利用できません"; // 利用不可の場合はエラーメッセージを返す
-                    }
-            }
-
-            //貸出可否チェック（登録時）
-            public String rentalCheck(RentalManageService rentalManageService,RentalManageDto rentalManageDto, String id) {
-                List<RentalManage> rentalAvailable = rentalManageService.findByStockIdAndStatusIn(id);
-                if (rentalAvailable != null) {
-                    // ループ処理
-                    for (RentalManage rentalManage : rentalAvailable) {
-                        if (rentalManage.getExpectedReturnOn().after(rentalManageDto.getExpectedRentalOn())
-                                && rentalManage.getExpectedRentalOn().before(rentalManageDto.getExpectedReturnOn())) {
-                            return "貸出期間が重複しています";
-                        }
-                    }
-                    return null;
-                } else {
-                    return null;
-                }
-            }
-
-            //貸出可否チェック(更新時)
-            public String rentalCheck(RentalManageService rentalManageService, RentalManageDto rentalManageDto, String id, Long rentalId) {
-                List<RentalManage> rentalAvailable = rentalManageService.findByStockIdAndStatusIn(id, rentalId);
-                if (rentalAvailable != null) {
-                // ループ処理
-                    for (RentalManage rentalManage : rentalAvailable) {
-                        if (rentalManage.getExpectedReturnOn().after(rentalManageDto.getExpectedRentalOn())
-                        && rentalManage.getExpectedRentalOn().before(rentalManageDto.getExpectedReturnOn())) {
-                        return "貸出期間が重複しています";
-                    }
-                }
-                return null;
-            } else {
-                return null;
-            }
     }
-    
-            //貸出ステータス変更時の日付チェック
-            public String isValidDate(RentalManageDto rentalManageDto, RentalManage rentalManage) {
-                LocalDate currentDate = LocalDate.now(ZoneId.of("Asia/Tokyo")); // 現在の日付を取得。おそらく貸出開始日のタイムゾーンがずれている
-            
-                // rentalDateとreturnDateをLocalDateに変換
-                LocalDate rentalDate = rentalManageDto.getExpectedRentalOn().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
-                LocalDate returnDate = rentalManageDto.getExpectedReturnOn().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
-            
-                Integer oldStatus = rentalManage.getStatus();
-                Integer newStatus = rentalManageDto.getStatus();
-            
-                if (oldStatus == 0 && newStatus == 1) {
-                    if (!rentalDate.equals(currentDate)) {
-                        return "貸出予定日は現在の日付で登録して下さい";
-                    }
+    //// ここまで
+
+    //// 加えました（5/14）
+    // 貸出状態が有効かどうかをチェックするメソッド
+    public String isValidStatus(Integer previousStatus) {
+        if (previousStatus == RentalStatus.RENT_WAIT.getValue() && this.status == RentalStatus.RETURNED.getValue()) {
+            return "貸出ステータスは「貸出待ち」から「返却済み」に変更できません";
+        } else if (previousStatus == RentalStatus.RENTAlING.getValue()
+                && this.status == RentalStatus.RENT_WAIT.getValue()) {
+            return "貸出ステータスは「貸出中」から「貸出待ち」に変更できません";
+        } else if (previousStatus == RentalStatus.RENTAlING.getValue()
+                && this.status == RentalStatus.CANCELED.getValue()) {
+            return "貸出ステータスは「貸出中」から「キャンセル」に変更できません";
+        } else if (previousStatus == RentalStatus.RETURNED.getValue()
+                && this.status == RentalStatus.RENT_WAIT.getValue()) {
+            return "貸出ステータスは「返却済み」から「貸出待ち」に変更できません";
+        } else if (previousStatus == RentalStatus.RETURNED.getValue()
+                && this.status == RentalStatus.RENTAlING.getValue()) {
+            return "貸出ステータスは「返却済み」から「貸出中」に変更できません";
+        } else if (previousStatus == RentalStatus.RETURNED.getValue()
+                && this.status == RentalStatus.CANCELED.getValue()) {
+            return "貸出ステータスは「返却済み」から「キャンセル」に変更できません";
+        } else if (previousStatus == RentalStatus.CANCELED.getValue()
+                && this.status == RentalStatus.RENT_WAIT.getValue()) {
+            return "貸出ステータスは「キャンセル」から「貸出待ち」に変更できません";
+        } else if (previousStatus == RentalStatus.CANCELED.getValue()
+                && this.status == RentalStatus.RENTAlING.getValue()) {
+            return "貸出ステータスは「キャンセル」から「貸出中」に変更できません";
+        } else if (previousStatus == RentalStatus.CANCELED.getValue()
+                && this.status == RentalStatus.RETURNED.getValue()) {
+            return "貸出ステータスは「キャンセル」から「返却済み」に変更できません";
+        }
+        return null;
+    }
+
+    // 貸出可否チェック（登録時）
+    public String rentalCheck(RentalManageService rentalManageService, RentalManageDto rentalManageDto, String id) {
+        List<RentalManage> rentalAvailable = rentalManageService.findByStockIdAndStatusIn(id);
+        if (rentalAvailable != null) {
+            // ループ処理
+            for (RentalManage rentalManage : rentalAvailable) {
+                if (rentalManage.getExpectedReturnOn().after(rentalManageDto.getExpectedRentalOn())
+                        &&
+                        rentalManage.getExpectedRentalOn().before(rentalManageDto.getExpectedReturnOn())) {
+                    return "貸出期間が重複しています";
                 }
-                if (oldStatus == 1 && newStatus == 2) {
-                    if (!returnDate.equals(currentDate)) {
-                        return "返却予定日は現在の日付で登録して下さい";
-                    }
+            }
+            return null;
+        } else {
+            return null;
+        }
+    }
+
+    // 貸出可否チェック(更新時)
+    public String rentalCheck(RentalManageService rentalManageService,
+            RentalManageDto rentalManageDto, String id, Long rentalId) {
+        List<RentalManage> rentalAvailable = rentalManageService.findByStockIdAndStatusIn(id, rentalId);
+        if (rentalAvailable != null) {
+            // ループ処理
+            for (RentalManage rentalManage : rentalAvailable) {
+                if (rentalManage.getExpectedReturnOn().after(rentalManageDto.getExpectedRentalOn())
+                        &&
+                        rentalManage.getExpectedRentalOn().before(rentalManageDto.getExpectedReturnOn())) {
+                    return "貸出期間が重複しています";
                 }
-                if (rentalDate.isAfter(returnDate)) {
-                    return "貸出予定日は返却予定日よりも前に設定してください";
-                }
-                return null;
-            } */
+            }
+            return null;
+        } else {
+            return null;
+        }
+    }
+
+    // 貸出ステータス変更時の日付チェック
+    public String isValidDate(RentalManageDto rentalManageDto, RentalManage rentalManage) {
+        LocalDate currentDate = LocalDate.now(ZoneId.of("Asia/Tokyo")); // 現在の日付を取得。
+        // rentalDateとreturnDateをLocalDateに変換
+        LocalDate rentalDate = rentalManageDto.getExpectedRentalOn().toInstant().atZone(ZoneId.systemDefault())
+                .toLocalDate();
+        LocalDate returnDate = rentalManageDto.getExpectedReturnOn().toInstant().atZone(ZoneId.systemDefault())
+                .toLocalDate();
+
+        Integer oldStatus = rentalManage.getStatus();
+        Integer newStatus = rentalManageDto.getStatus();
+
+        if (oldStatus == 0 && newStatus == 1) {
+            if (!rentalDate.equals(currentDate)) {
+                return "貸出予定日は現在の日付で登録して下さい";
+            }
+        }
+        if (oldStatus == 1 && newStatus == 2) {
+            if (!returnDate.equals(currentDate)) {
+                return "返却予定日は現在の日付で登録して下さい";
+            }
+        }
+        if (rentalDate.isAfter(returnDate)) {
+            return "貸出予定日は返却予定日よりも前に設定してください";
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -10,6 +10,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jp.co.metateam.library.values.RentalStatus;
+import jp.co.metateam.library.values.StockStatus;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -150,12 +151,12 @@ public class RentalManageDto {
         Integer oldStatus = rentalManage.getStatus();
         Integer newStatus = rentalManageDto.getStatus();
 
-        if (oldStatus == 0 && newStatus == 1) {
+        if (oldStatus == RentalStatus.RENT_WAIT.getValue() && newStatus == RentalStatus.RENTAlING.getValue()) {
             if (!rentalDate.equals(currentDate)) {
                 return "貸出予定日は現在の日付で登録して下さい";
             }
         }
-        if (oldStatus == 1 && newStatus == 2) {
+        if (oldStatus == RentalStatus.RENTAlING.getValue() && newStatus == RentalStatus.RETURNED.getValue()) {
             if (!returnDate.equals(currentDate)) {
                 return "返却予定日は現在の日付で登録して下さい";
             }

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -1,7 +1,9 @@
 package jp.co.metateam.library.model;
 
 import java.sql.Timestamp;
+/* import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.ZoneId; */
 import java.util.Date;
 
 import org.springframework.format.annotation.DateTimeFormat;
@@ -11,6 +13,9 @@ import jakarta.validation.constraints.NotNull;
 import jp.co.metateam.library.values.RentalStatus;
 import lombok.Getter;
 import lombok.Setter;
+
+/* import jp.co.metateam.library.service.RentalManageService;
+import jp.co.metateam.library.service.StockService; */
 
 
 /**
@@ -88,13 +93,77 @@ public class RentalManageDto {
                 return null;
             }
 
-            public boolean isValidRentalDate() {
-                LocalDate today = LocalDate.now();
-                return expectedRentalOn.equals(today); // または必要に応じて条件を調整
+            //Controller　→　Dto移行用
+/*             //利用可日チェック
+            private StockService stockService;
+            public String checkInventoryStatus(String id) {
+                // 在庫ステータスを確認するロジックを記述
+                Stock stock = stockService.findById(id);
+                    if (stock.getStatus() == 0) {
+                        return null; // 利用可の場合はエラーメッセージなし
+                    } else {
+                        return "この本は利用できません"; // 利用不可の場合はエラーメッセージを返す
+                    }
             }
-            public boolean isValidReturnDate() {
-                LocalDate today = LocalDate.now();
-                return expectedReturnOn.equals(today); // または必要に応じて条件を調整
+
+            //貸出可否チェック（登録時）
+            public String rentalCheck(RentalManageService rentalManageService,RentalManageDto rentalManageDto, String id) {
+                List<RentalManage> rentalAvailable = rentalManageService.findByStockIdAndStatusIn(id);
+                if (rentalAvailable != null) {
+                    // ループ処理
+                    for (RentalManage rentalManage : rentalAvailable) {
+                        if (rentalManage.getExpectedReturnOn().after(rentalManageDto.getExpectedRentalOn())
+                                && rentalManage.getExpectedRentalOn().before(rentalManageDto.getExpectedReturnOn())) {
+                            return "貸出期間が重複しています";
+                        }
+                    }
+                    return null;
+                } else {
+                    return null;
+                }
             }
+
+            //貸出可否チェック(更新時)
+            public String rentalCheck(RentalManageService rentalManageService, RentalManageDto rentalManageDto, String id, Long rentalId) {
+                List<RentalManage> rentalAvailable = rentalManageService.findByStockIdAndStatusIn(id, rentalId);
+                if (rentalAvailable != null) {
+                // ループ処理
+                    for (RentalManage rentalManage : rentalAvailable) {
+                        if (rentalManage.getExpectedReturnOn().after(rentalManageDto.getExpectedRentalOn())
+                        && rentalManage.getExpectedRentalOn().before(rentalManageDto.getExpectedReturnOn())) {
+                        return "貸出期間が重複しています";
+                    }
+                }
+                return null;
+            } else {
+                return null;
+            }
+    }
     
+            //貸出ステータス変更時の日付チェック
+            public String isValidDate(RentalManageDto rentalManageDto, RentalManage rentalManage) {
+                LocalDate currentDate = LocalDate.now(ZoneId.of("Asia/Tokyo")); // 現在の日付を取得。おそらく貸出開始日のタイムゾーンがずれている
+            
+                // rentalDateとreturnDateをLocalDateに変換
+                LocalDate rentalDate = rentalManageDto.getExpectedRentalOn().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+                LocalDate returnDate = rentalManageDto.getExpectedReturnOn().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+            
+                Integer oldStatus = rentalManage.getStatus();
+                Integer newStatus = rentalManageDto.getStatus();
+            
+                if (oldStatus == 0 && newStatus == 1) {
+                    if (!rentalDate.equals(currentDate)) {
+                        return "貸出予定日は現在の日付で登録して下さい";
+                    }
+                }
+                if (oldStatus == 1 && newStatus == 2) {
+                    if (!returnDate.equals(currentDate)) {
+                        return "返却予定日は現在の日付で登録して下さい";
+                    }
+                }
+                if (rentalDate.isAfter(returnDate)) {
+                    return "貸出予定日は返却予定日よりも前に設定してください";
+                }
+                return null;
+            } */
 }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
@@ -16,4 +17,24 @@ public interface RentalManageRepository extends JpaRepository<RentalManage, Long
 
     @NonNull
     Optional<RentalManage> findById(@NonNull Long id);
+
+    //追加(5/16)
+    //JPQL（Java Persistence Query Language）またはSQLクエリを指定
+    @Query("select rm"
+            + " from RentalManage rm " + " where (rm.status = 0 or rm.status = 1)"
+            + " and rm.stock.id = ?1 "
+            + " and rm.id <> ?2")
+        List<RentalManage> findByStockIdAndStatusIn(String Id,Long rentalId);
+
+    @Query("select rm"
+            + " from RentalManage rm " + " where (rm.status = 0 or rm.status = 1)"
+            + " and rm.stock.id = ?1 ")
+    List<RentalManage> findByStockIdAndStatusIn(String Id);
+    //ここまで
+    /*
+     * 1.2.3.4.5 rentalId
+     * A.A.A.A.A id
+     * String Id →　1.2.3.4.5のレコード５行取得
+     * Long rentalId　→  rm.id ≠ 1 →　.2.3.4.5のレコード４行取得
+     */
 }

--- a/src/main/java/jp/co/metateam/library/service/RentalManageService.java
+++ b/src/main/java/jp/co/metateam/library/service/RentalManageService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import jp.co.metateam.library.model.Account;
 
-
 import jp.co.metateam.library.model.RentalManage;
 import jp.co.metateam.library.model.RentalManageDto;
 import jp.co.metateam.library.model.Stock;
@@ -18,8 +17,6 @@ import jp.co.metateam.library.repository.RentalManageRepository;
 import jp.co.metateam.library.repository.StockRepository;
 import jp.co.metateam.library.values.RentalStatus;
 
-
-
 @Service
 public class RentalManageService {
 
@@ -27,20 +24,19 @@ public class RentalManageService {
     private final RentalManageRepository rentalManageRepository;
     private final StockRepository stockRepository;
 
-     @Autowired
+    @Autowired
     public RentalManageService(
-        AccountRepository accountRepository,
-        RentalManageRepository rentalManageRepository,
-        StockRepository stockRepository
-    ) {
+            AccountRepository accountRepository,
+            RentalManageRepository rentalManageRepository,
+            StockRepository stockRepository) {
         this.accountRepository = accountRepository;
         this.rentalManageRepository = rentalManageRepository;
         this.stockRepository = stockRepository;
     }
 
     @Transactional
-    public List <RentalManage> findAll() {
-        List <RentalManage> rentalManageList = this.rentalManageRepository.findAll();
+    public List<RentalManage> findAll() {
+        List<RentalManage> rentalManageList = this.rentalManageRepository.findAll();
 
         return rentalManageList;
     }
@@ -50,7 +46,7 @@ public class RentalManageService {
         return this.rentalManageRepository.findById(id).orElse(null);
     }
 
-    @Transactional 
+    @Transactional
     public void save(RentalManageDto rentalManageDto) throws Exception {
         try {
             Account account = this.accountRepository.findByEmployeeId(rentalManageDto.getEmployeeId()).orElse(null);
@@ -79,15 +75,13 @@ public class RentalManageService {
         }
     }
 
+    // アップデートを追加します
 
-    //アップデートを追加します
-    
     @Transactional
     public void update(Long id, RentalManageDto rentalManageDto) throws Exception {
-       
-       
+
         try {
- 
+
             Account account = this.accountRepository.findByEmployeeId(rentalManageDto.getEmployeeId()).orElse(null);
             if (account == null) {
                 throw new Exception("Rental record not found.");
@@ -96,24 +90,21 @@ public class RentalManageService {
             if (stock == null) {
                 throw new Exception("Rental record not found.");
             }
-           
+
             RentalManage rentalManage = this.rentalManageRepository.findById(id).orElse(null);
             if (rentalManage == null) {
                 throw new Exception("RentalManage record not found.");
             }
- 
-                setRentalStatusDate(rentalManage, rentalManageDto.getStatus());
-   
-                rentalManage.setId(rentalManageDto.getId());
-                rentalManage.setAccount(account);
-                rentalManage.setExpectedRentalOn(rentalManageDto.getExpectedRentalOn());
-                rentalManage.setExpectedReturnOn(rentalManageDto.getExpectedReturnOn());
-                rentalManage.setStatus(rentalManageDto.getStatus());
-                rentalManage.setStock(stock);
-   
-   
-               
-   
+
+            setRentalStatusDate(rentalManage, rentalManageDto.getStatus());
+
+            rentalManage.setId(rentalManageDto.getId());
+            rentalManage.setAccount(account);
+            rentalManage.setExpectedRentalOn(rentalManageDto.getExpectedRentalOn());
+            rentalManage.setExpectedReturnOn(rentalManageDto.getExpectedReturnOn());
+            rentalManage.setStatus(rentalManageDto.getStatus());
+            rentalManage.setStock(stock);
+
             // データベースへの保存
             this.rentalManageRepository.save(rentalManage);
         } catch (Exception e) {
@@ -124,7 +115,7 @@ public class RentalManageService {
 
     private RentalManage setRentalStatusDate(RentalManage rentalManage, Integer status) {
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());
-        
+
         if (status == RentalStatus.RENTAlING.getValue()) {
             rentalManage.setRentaledAt(timestamp);
         } else if (status == RentalStatus.RETURNED.getValue()) {
@@ -136,17 +127,18 @@ public class RentalManageService {
         return rentalManage;
     }
 
-    ///ここから追加(5/16)
+    /// ここから追加(5/16)
     @Transactional
-    public List<RentalManage> findByStockIdAndStatusIn(String Id,Long rentalId){
-        List<RentalManage> rentalAvailable = this.rentalManageRepository.findByStockIdAndStatusIn(Id,rentalId);
+    public List<RentalManage> findByStockIdAndStatusIn(String Id, Long rentalId) {
+        List<RentalManage> rentalAvailable = this.rentalManageRepository.findByStockIdAndStatusIn(Id, rentalId);
         return rentalAvailable;
     }
+
     @Transactional
-    public List<RentalManage> findByStockIdAndStatusIn(String Id){
+    public List<RentalManage> findByStockIdAndStatusIn(String Id) {
         List<RentalManage> rentalAvailable = this.rentalManageRepository.findByStockIdAndStatusIn(Id);
         return rentalAvailable;
     }
-    ///ここまで
+    /// ここまで
 
 }

--- a/src/main/java/jp/co/metateam/library/service/RentalManageService.java
+++ b/src/main/java/jp/co/metateam/library/service/RentalManageService.java
@@ -19,6 +19,7 @@ import jp.co.metateam.library.repository.StockRepository;
 import jp.co.metateam.library.values.RentalStatus;
 
 
+
 @Service
 public class RentalManageService {
 
@@ -121,7 +122,6 @@ public class RentalManageService {
 
     }
 
-
     private RentalManage setRentalStatusDate(RentalManage rentalManage, Integer status) {
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());
         
@@ -135,4 +135,18 @@ public class RentalManageService {
 
         return rentalManage;
     }
+
+    ///ここから追加(5/16)
+    @Transactional
+    public List<RentalManage> findByStockIdAndStatusIn(String Id,Long rentalId){
+        List<RentalManage> rentalAvailable = this.rentalManageRepository.findByStockIdAndStatusIn(Id,rentalId);
+        return rentalAvailable;
+    }
+    @Transactional
+    public List<RentalManage> findByStockIdAndStatusIn(String Id){
+        List<RentalManage> rentalAvailable = this.rentalManageRepository.findByStockIdAndStatusIn(Id);
+        return rentalAvailable;
+    }
+    ///ここまで
+
 }

--- a/src/main/java/jp/co/metateam/library/values/RentalStatus.java
+++ b/src/main/java/jp/co/metateam/library/values/RentalStatus.java
@@ -6,13 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum RentalStatus implements Values {
-    RENT_WAIT(0, "貸出待ち")
-    , RENTAlING(1, "貸出中")
-    , RETURNED(2, "返却済み")
-    , CANCELED(3, "キャンセル");
+    RENT_WAIT(0, "貸出待ち"), RENTAlING(1, "貸出中"), RETURNED(2, "返却済み"), CANCELED(3, "キャンセル");
 
     private final Integer value;
-    private final String text;  
+    private final String text;
 
-    
 }


### PR DESCRIPTION
**概要**
貸出編集画面の「貸出可否チェック」・「日付チェック」
・貸出可否チェックでは、DtoのデータとRentalMangeテーブルのデータを比較し、貸出予定期間に重複があればエラー
・日付チェックでは、貸出ステータスを「貸出待ち」→「貸出中」と「貸出中」→「返却済み」に変更した際に、前者の場合は貸出予定日が、後者の場合は返却予定日が現在日になるように実装

**テスト証跡**
【貸出可否チェック】
貸出編集画面or登録画面を開く
→貸出予定日、返却予定日を更新or登録する
重複時→エラーメッセージ表示→編集or登録画面にとどまる
非重複時→データをRentalMangeテーブルに更新or登録→貸出一覧画面に遷移

【貸出可否チェック】
貸出編集画面を開く
→ステータスを「貸出待ち」→「貸出中」or「貸出中」→「返却済み」
現在日ではないとき→エラーメッセージ表示→編集画面にとどまる
現在日→データをRentalMangeテーブルにて更新→貸出一覧画面に遷移

**備考**
バリデーションチェックのメソッドをControllerに書いてしまっています。本日5/21の午後からそれらのメソッドをDtoに移していきます。


