### PR TITLE
在庫カレンダー機能、貸出登録・編集におけるバリデーションの追加

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -18,6 +18,7 @@ import jakarta.validation.Valid;
 import jp.co.metateam.library.model.BookMst;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
+
 import jp.co.metateam.library.service.BookMstService;
 import jp.co.metateam.library.service.StockService;
 import jp.co.metateam.library.values.StockStatus;
@@ -37,11 +38,12 @@ public class StockController {
     public StockController(BookMstService bookMstService, StockService stockService) {
         this.bookMstService = bookMstService;
         this.stockService = stockService;
+
     }
 
     @GetMapping("/stock/index")
     public String index(Model model) {
-        List <Stock> stockList = this.stockService.findAll();
+        List<Stock> stockList = this.stockService.findAll();
 
         model.addAttribute("stockList", stockList);
 
@@ -113,7 +115,8 @@ public class StockController {
     }
 
     @PostMapping("/stock/{id}/edit")
-    public String update(@PathVariable("id") String id, @Valid @ModelAttribute StockDto stockDto, BindingResult result, RedirectAttributes ra) {
+    public String update(@PathVariable("id") String id, @Valid @ModelAttribute StockDto stockDto, BindingResult result,
+            RedirectAttributes ra) {
         try {
             if (result.hasErrors()) {
                 throw new Exception("Validation error.");
@@ -133,7 +136,8 @@ public class StockController {
     }
 
     @GetMapping("/stock/calendar")
-    public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month, Model model) {
+    public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month,
+            Model model) {
 
         LocalDate today = year == null || month == null ? LocalDate.now() : LocalDate.of(year, month, 1);
         Integer targetYear = year == null ? today.getYear() : year;
@@ -142,15 +146,16 @@ public class StockController {
         LocalDate startDate = LocalDate.of(targetYear, targetMonth, 1);
         Integer daysInMonth = startDate.lengthOfMonth();
 
-        List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth);
-        List<String> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
+        List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, daysInMonth);
 
+        List<Object[]> bookData = this.stockService.generateBookData(model, targetYear, targetMonth);
+
+        // ビューにデータを渡す
         model.addAttribute("targetYear", targetYear);
         model.addAttribute("targetMonth", targetMonth);
         model.addAttribute("daysOfWeek", daysOfWeek);
         model.addAttribute("daysInMonth", daysInMonth);
-
-        model.addAttribute("stocks", stocks);
+        model.addAttribute("bookData", bookData);
 
         return "stock/calendar";
     }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -9,32 +9,39 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.RentalManage;
+import java.util.Date;
 
 @Repository
 public interface RentalManageRepository extends JpaRepository<RentalManage, Long> {
-    @NonNull
-    List<RentalManage> findAll();
+        @NonNull
+        List<RentalManage> findAll();
 
-    @NonNull
-    Optional<RentalManage> findById(@NonNull Long id);
+        @NonNull
+        Optional<RentalManage> findById(@NonNull Long id);
 
-    //追加(5/16)
-    //JPQL（Java Persistence Query Language）またはSQLクエリを指定
-    @Query("select rm"
-            + " from RentalManage rm " + " where (rm.status = 0 or rm.status = 1)"
-            + " and rm.stock.id = ?1 "
-            + " and rm.id <> ?2")
-        List<RentalManage> findByStockIdAndStatusIn(String Id,Long rentalId);
+        // 追加(5/16)
+        // JPQL（Java Persistence Query Language）またはSQLクエリを指定
+        @Query("select rm"
+                        + " from RentalManage rm " + " where (rm.status = 0 or rm.status = 1)"
+                        + " and rm.stock.id = ?1 "
+                        + " and rm.id <> ?2")
+        List<RentalManage> findByStockIdAndStatusIn(String Id, Long rentalId);
 
-    @Query("select rm"
-            + " from RentalManage rm " + " where (rm.status = 0 or rm.status = 1)"
-            + " and rm.stock.id = ?1 ")
-    List<RentalManage> findByStockIdAndStatusIn(String Id);
-    //ここまで
-    /*
-     * 1.2.3.4.5 rentalId
-     * A.A.A.A.A id
-     * String Id →　1.2.3.4.5のレコード５行取得
-     * Long rentalId　→  rm.id ≠ 1 →　.2.3.4.5のレコード４行取得
-     */
+        @Query("select rm"
+                        + " from RentalManage rm " + " where (rm.status = 0 or rm.status = 1)"
+                        + " and rm.stock.id = ?1 ")
+        List<RentalManage> findByStockIdAndStatusIn(String Id);
+
+        // ここまで
+        /*
+         * 1.2.3.4.5 rentalId
+         * A.A.A.A.A id
+         * String Id → 1.2.3.4.5のレコード５行取得
+         * Long rentalId → rm.id ≠ 1 → .2.3.4.5のレコード４行取得
+         */
+        @Query(value = "SELECT COUNT(*) FROM rental_manage rm INNER JOIN stocks s ON rm.stock_id = s.id INNER JOIN book_mst bm ON s.book_id = bm.id"
+                        + " WHERE bm.title = ?1 AND (rm.expected_rental_on <= ?2 AND rm.expected_return_on >= ?2) AND (rm.status = 0 OR rm.status = 1)", nativeQuery = true)
+        Long countBySpecifiedDateRentals(String title, Date specifiedDate);
+
+        RentalManage findByExpectedRentalOn(Date expectedRentalOn);
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -1,23 +1,55 @@
 package jp.co.metateam.library.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
+import jp.co.metateam.library.model.RentalManage;
 import jp.co.metateam.library.model.Stock;
 
 @Repository
 public interface StockRepository extends JpaRepository<Stock, Long> {
-    
-    List<Stock> findAll();
 
-    List<Stock> findByDeletedAtIsNull();
+        @NonNull
+        List<Stock> findAll();
 
-    List<Stock> findByDeletedAtIsNullAndStatus(Integer status);
+        @NonNull
+        List<Stock> findByDeletedAtIsNull();
 
-	Optional<Stock> findById(String id);
-    
-    List<Stock> findByBookMstIdAndStatus(Long book_id,Integer status);
+        @NonNull
+        List<Stock> findByDeletedAtIsNullAndStatus(Integer status);
+
+        @NonNull
+        Optional<Stock> findById(String id);
+
+        @NonNull
+        List<Stock> findByBookMstIdAndStatus(Long book_id, Integer status);
+
+        @Query("SELECT COUNT(*) AS count " +
+                        "FROM BookMst bm " +
+                        "JOIN Stock s ON bm.id = s.bookMst.id AND s.status = 0 " +
+                        "GROUP BY bm.title")
+        List<Long> countStocksByBookTitle();
+
+        // @Query("SELECT COUNT(DISTINCT bm.title) FROM Stock s JOIN s.bookMst bm WHERE
+        // s.status = 0")
+        // Long countStocksByBookTitle();
+
+        @Query("select rm"
+                        + " from RentalManage rm "
+                        + " where (rm.status = 0 or rm.status = 1)")
+        List<RentalManage> rentalManage0or1();
+
+        @Query(value = "SELECT s.id " +
+                        "FROM stocks s " +
+                        "LEFT JOIN rental_manage rm ON s.id = rm.stock_id " +
+                        "INNER JOIN book_mst bm ON s.book_id = bm.id " +
+                        "WHERE bm.title = ?1 AND (rm.expected_rental_on IS NULL OR rm.expected_rental_on > ?2 OR rm.expected_return_on < ?2) AND s.status = 0", nativeQuery = true)
+        List<String> stockIdAvailableRental(String title, LocalDate currentDate);
+
 }

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -1,11 +1,12 @@
 package jp.co.metateam.library.service;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Random;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -18,15 +19,25 @@ import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.repository.BookMstRepository;
 import jp.co.metateam.library.repository.StockRepository;
 
+import org.springframework.ui.Model;
+
+import java.util.Date;
+import jp.co.metateam.library.repository.RentalManageRepository;
+import java.util.Map;
+import java.time.YearMonth;
+
 @Service
 public class StockService {
     private final BookMstRepository bookMstRepository;
     private final StockRepository stockRepository;
+    private final RentalManageRepository rentalManageRepository;
 
     @Autowired
-    public StockService(BookMstRepository bookMstRepository, StockRepository stockRepository){
+    public StockService(BookMstRepository bookMstRepository, StockRepository stockRepository,
+            RentalManageRepository rentalManageRepository) {
         this.bookMstRepository = bookMstRepository;
         this.stockRepository = stockRepository;
+        this.rentalManageRepository = rentalManageRepository;
     }
 
     @Transactional
@@ -35,10 +46,10 @@ public class StockService {
 
         return stocks;
     }
-    
+
     @Transactional
-    public List <Stock> findStockAvailableAll() {
-        List <Stock> stocks = this.stockRepository.findByDeletedAtIsNullAndStatus(Constants.STOCK_AVAILABLE);
+    public List<Stock> findStockAvailableAll() {
+        List<Stock> stocks = this.stockRepository.findByDeletedAtIsNullAndStatus(Constants.STOCK_AVAILABLE);
 
         return stocks;
     }
@@ -48,7 +59,7 @@ public class StockService {
         return this.stockRepository.findById(id).orElse(null);
     }
 
-    @Transactional 
+    @Transactional
     public void save(StockDto stockDto) throws Exception {
         try {
             Stock stock = new Stock();
@@ -69,7 +80,7 @@ public class StockService {
         }
     }
 
-    @Transactional 
+    @Transactional
     public void update(String id, StockDto stockDto) throws Exception {
         try {
             Stock stock = findById(id);
@@ -94,7 +105,7 @@ public class StockService {
         }
     }
 
-    public List<Object> generateDaysOfWeek(int year, int month, LocalDate startDate, int daysInMonth) {
+    public List<Object> generateDaysOfWeek(int year, int month, int daysInMonth) {
         List<Object> daysOfWeek = new ArrayList<>();
         for (int dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++) {
             LocalDate date = LocalDate.of(year, month, dayOfMonth);
@@ -105,19 +116,77 @@ public class StockService {
         return daysOfWeek;
     }
 
-    public List<String> generateValues(Integer year, Integer month, Integer daysInMonth) {
-        // FIXME ここで各書籍毎の日々の在庫を生成する処理を実装する
-        // FIXME ランダムに値を返却するサンプルを実装している
-        String[] stockNum = {"1", "2", "3", "4", "×"};
-        Random rnd = new Random();
-        List<String> values = new ArrayList<>();
-        values.add("スッキリわかるJava入門 第4版"); // 対象の書籍名
-        values.add("10"); // 対象書籍の在庫総数
-        
-        for (int i = 1; i <= daysInMonth; i++) {
-            int index = rnd.nextInt(stockNum.length);
-            values.add(stockNum[index]);
+    // 現在の年と月を取得
+    YearMonth currentYearMonth = YearMonth.now();
+    int currentYear = currentYearMonth.getYear();
+    int currentMonth = currentYearMonth.getMonthValue();
+
+    public List<Object[]> generateBookData(Model model, int year, int month) {
+        List<Stock> stocks = findAll(); // 在庫情報を取得
+
+        // 書籍名ごとの在庫数を保持するMapを作成
+        Map<String, Long> bookCountMap = new HashMap<>();
+        for (Stock stock : stocks) {
+            String bookName = stock.getBookMst().getTitle();
+            // 在庫ステータスが０の場合のみカウント
+            if (stock.getStatus() == 0) {
+                bookCountMap.put(bookName, bookCountMap.getOrDefault(bookName, 0L) + 1);
+            }
         }
-        return values;
+
+        // 書籍名と在庫数を組み合わせた2次元配列を作成する
+        List<Object[]> bookData = new ArrayList<>();
+        for (Map.Entry<String, Long> entry : bookCountMap.entrySet()) {
+            String bookName = entry.getKey();
+            Long stockCount = entry.getValue();
+            Object[] row = { bookName, stockCount };
+            bookData.add(row);
+        }
+
+        // 各書籍ごとに各日の在庫数を計算して配列に追加
+        List<Object[]> updatedBookData = new ArrayList<>();
+        for (Object[] row : bookData) {
+            String title = (String) row[0];
+            Long stockCount = (Long) row[1];
+
+            // 各日の在庫状況を格納する配列を作成
+            Object[] stockInfo = new Object[getDaysInMonth(year, month) + 2];
+
+            stockInfo[0] = title; // 書籍名を配列の最初の要素に格納
+            stockInfo[1] = stockCount; // 在庫数を配列の2番目の要素に格納
+
+            // 各日の在庫状況を計算して配列に格納
+            for (int dayOfMonth = 1; dayOfMonth <= getDaysInMonth(year, month); dayOfMonth++) {
+                LocalDate currentDate = LocalDate.of(year, month, dayOfMonth);
+                Date specifiedDate = Date.from(currentDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+                Long rentalCount = this.rentalManageRepository.countBySpecifiedDateRentals(title, specifiedDate);
+                Long countAvailableRental = stockCount - rentalCount;
+                List<String> stockIdAvailableRental = this.stockRepository.stockIdAvailableRental(title, currentDate);
+                String stockIdAvailebleRentalIndex1 = (stockIdAvailableRental != null
+                        && !stockIdAvailableRental.isEmpty()) ? stockIdAvailableRental.get(0) : "×";
+
+                List<Object> infoList = new ArrayList<>();
+
+                infoList.add(currentDate); // 日付
+                infoList.add(stockIdAvailebleRentalIndex1); // 在庫管理番号
+                infoList.add(countAvailableRental); // 在庫数
+
+                stockInfo[dayOfMonth + 1] = infoList;
+            }
+            // 書籍情報をupdatedBookDataに追加
+            updatedBookData.add(stockInfo);
+        }
+
+        // Modelに書籍データを追加する
+        model.addAttribute("bookData", updatedBookData);
+
+        // 生成された書籍データを返す
+        return updatedBookData;
     }
+
+    public int getDaysInMonth(int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        return yearMonth.lengthOfMonth();
+    }
+
 }

--- a/src/main/resources/templates/rental/add.html
+++ b/src/main/resources/templates/rental/add.html
@@ -14,13 +14,15 @@
             <div th:replace="~{common :: header}"></div>
             <div class="inner_contens">
                 <div class="page_title">貸出登録</div>
+
                 <div class="mb30 flexarea">
                     <span class="text-red">＊は必須項目です</span>
                     <span>
                         <a th:href="@{/rental/index}" class="link">← 一覧へ戻る</a>
                     </span>
                 </div>
-                <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/add}" method="post">
+                <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/add}" method="post"
+                    novalidate>
                     <div class="mb30">
                         <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
                         <select id="employeeId" class="form_input" name="employeeId" required>
@@ -36,11 +38,11 @@
                         <label class="input_title" for="expectedRentalOn">貸出予定日<span
                                 class="text-red asterisk">＊</span></label>
                         <input type="date" id="expectedRentalOn" class="form_input" name="expectedRentalOn"
-                            th:value="${#dates.format(rentalManageDto.expectedRentalOn, ('yyyy-MM-dd'))}"
-                            placeholder="貸出予定日を入力" required>
+                            th:value="${#dates.format(currentDate, 'yyyy-MM-dd')}" placeholder="貸出予定日を入力" required>
                         <div class="error_msg" th:if="${#fields.hasErrors('expectedRentalOn')}"
                             th:errors="*{expectedRentalOn}"></div>
                     </div>
+
                     <div class="mb30">
                         <label class="input_title" for="expectedReturnOn">返却予定日<span
                                 class="text-red asterisk">＊</span></label>
@@ -58,9 +60,13 @@
                             <option th:each="stock : ${stockList}" th:value="${stock.id}"
                                 th:text="${stock.id + ' ' + stock.bookMst.title}"
                                 th:selected="${stock.id == rentalManageDto.stockId}"></option>
+                            <option th:if="${stock != null}" th:value="${stock.id}"
+                                th:text="${stock.id + ' ' + stock.bookMst.title}" th:selected="${stock.id == stock.id}">
+                            </option> <!-- 新しいオプションを追加 -->
                         </select>
                         <div class="error_msg" th:if="${#fields.hasErrors('stockId')}" th:errors="*{stockId}"></div>
                     </div>
+
                     <div class="mb30">
                         <label class="input_title" for="rentalStatus">貸出ステータス<span
                                 class="text-red asterisk">＊</span></label>

--- a/src/main/resources/templates/rental/edit.html
+++ b/src/main/resources/templates/rental/edit.html
@@ -7,6 +7,7 @@
     <script type="text/javascript" th:src="@{/js/rental/edit.js}"></script>
 </head>
 
+
 <body>
     <div class="contents">
         <div th:replace="~{common :: main_sidebar}"></div>
@@ -20,7 +21,8 @@
                         <a th:href="@{/rental/index}" class="link">← 一覧へ戻る</a>
                     </span>
                 </div>
-                <form id="rental_edit_form" th:object="${rentalManageDto}" th:action="@{/rental/{id}/edit(id=*{id})}" method="post">
+                <form id="rental_edit_form" th:object="${rentalManageDto}" th:action="@{/rental/{id}/edit(id=*{id})}"
+                    method="post" novalidate>
 
                     <div class="mb30">
                         <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
@@ -73,7 +75,7 @@
                         </select>
                         <div class="error_msg" th:if="${#fields.hasErrors('status')}" th:errors="*{status}"></div>
                     </div>
-                    
+
                     <!-- エラーメッセージを追加 -->
                     <div th:if="${errorMessage}" class="alert alert-danger" role="alert">
                         <p th:text="${errorMessage}"></p>

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
 <head th:replace="~{common :: meta_header('在庫カレンダー',~{::link},~{::script})}">
     <title th:text="${title}+' | MTLibrary'"></title>
     <link rel="stylesheet" th:href="@{/css/stock/calendar.css}" />
     <script type="text/javascript" th:src="@{/js/stock/add.js}"></script>
 </head>
+
 <body>
     <div class="contents">
         <div th:replace="~{common :: main_sidebar}"></div>
@@ -26,20 +28,36 @@
                             <col style="width: 70px;" th:each="i : ${#numbers.sequence(0,daysInMonth)}">
                         </colgroup>
                         <thead>
-                            <tr>
+                            <tr class="calendar_column">
                                 <th class="header_book" rowspan="2">書籍名</th>
                                 <th class="header_stock" rowspan="2">在庫数</th>
-                                <th class="header_days" th:colspan="${daysInMonth}" th:text="${targetYear + '年' + targetMonth + '月'}"></th>
                             </tr>
                             <tr class="days">
                                 <th th:each="day : ${daysOfWeek}" th:text="${day}"></th>
                             </tr>
                         </thead>
                         <tbody>
-                            <tr>
-                                <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
-                                <td th:each="stock, stat : ${stocks}" th:text="${stock}"></td>
+                            <!-- 書籍名、在庫数、および日ごとの在庫数を表示 -->
+                            <tr th:each="bookData : ${bookData}">
+                                <td th:text="${bookData[0]}"></td> <!-- 書籍名 -->
+                                <td th:text="${bookData[1]}"></td> <!-- 在庫数 -->
+                                <!-- 日ごとの在庫数 -->
+                                <td th:each="stockPerDay, index : ${bookData}" th:if="${index.index > 1}">
+                                    <span th:if="${stockPerDay[2] != 0}">
+                                        <a
+                                            th:href="@{/rental/add(stockIdAvailebleRentalIndex1=${stockPerDay[1]}, currentDate=${stockPerDay[0]})}">
+                                            <span th:text="${stockPerDay[2]}"></span>
+                                        </a>
+                                    </span>
+                                    <span th:unless="${stockPerDay[2] != 0}">
+                                        <span>×</span>
+                                    </span>
+                                </td>
+
                             </tr>
+                            <div th:text="${stockIdAvailebleRentalIndex1}"></div>
+                            <div th:text="${currentDate}"></div>
+
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
**概要**
　>在庫カレンダー機能の実装
　　　・StockService…在庫カレンダーを表示する際に必要な処理を実装
　　　・StockController…StockServiceで処理した内容をビューに渡す処理を追加
　　　・RentalMangeController…在庫カレンダーから貸出登録画面への遷移時の処理を追加

　>貸出登録・編集時における、日付に対してのフォーマットチェック機能の追加
　　　・RentalMangeDto…バリデーション機能を追加
　>貸出登録時、貸出予定日を過去の日付で登録できてしまう不具合を修正
　　　・RentalMangeDto…バリデーション機能を追加

**テスト証跡**
　>アコーディオン内の「在庫カレンダー」を押下→在庫カレンダーが表示される→特定の書籍・日付のセルにある貸出可能な在庫数のリンクを押下→選択した書籍の在庫管理番号と日付が初期値として設定された上で、貸出登録画面に遷移

　>貸出登録画面か編集画面に遷移→貸出予定日か返却予定日のフォーマットをyyyy-MM-dd以外の形式で入力→他の項目を適切な値で入力→保存（変更）ボタンを押下→エラーメッセージが表示される

　>貸出登録画面に遷移→貸出予定日の日付を過去の日付で選択→他の項目を適切な値で入力→保存→エラーメッセージが表示される
　
**備考**
過去の研修で、コード理解のために書いたコメントアウトのせいで見づらいかと思われます。削除しておきます。
テスト項目書作成に並行してリファクタリングを行う予定です。